### PR TITLE
In-module file_writer_control needs relative imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ mp-forwarder-teardown = 'mccode_plumber.forwarder:teardown'
 mp-writer-from = 'mccode_plumber.writer:print_time'
 mp-writer-write = 'mccode_plumber.writer:start_writer'
 mp-writer-wait = 'mccode_plumber.writer:wait_on_writer'
+mp-writer-list = 'mccode_plumber.writer:list_status'
+mp-writer-kill = 'mccode_plumber.writer:kill_job'
 mp-register-topics = 'mccode_plumber.kafka:register_topics'
 mp-insert-hdf5-instr = 'mccode_plumber.mccode:insert'
 

--- a/src/mccode_plumber/file_writer_control/CommandChannel.py
+++ b/src/mccode_plumber/file_writer_control/CommandChannel.py
@@ -7,14 +7,14 @@ from typing import Dict, List, Optional, Union
 from kafka import KafkaConsumer
 from kafka.errors import NoBrokersAvailable
 
-from file_writer_control.CommandStatus import CommandState, CommandStatus
-from file_writer_control.InThreadStatusTracker import (
+from .CommandStatus import CommandState, CommandStatus
+from .InThreadStatusTracker import (
     DEAD_ENTITY_TIME_LIMIT,
     InThreadStatusTracker,
 )
-from file_writer_control.JobStatus import JobStatus
-from file_writer_control.KafkaTopicUrl import KafkaTopicUrl
-from file_writer_control.WorkerStatus import WorkerStatus
+from .JobStatus import JobStatus
+from .KafkaTopicUrl import KafkaTopicUrl
+from .WorkerStatus import WorkerStatus
 
 
 def thread_function(

--- a/src/mccode_plumber/file_writer_control/CommandHandler.py
+++ b/src/mccode_plumber/file_writer_control/CommandHandler.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
-from file_writer_control.CommandChannel import CommandChannel
-from file_writer_control.CommandStatus import CommandState
+from .CommandChannel import CommandChannel
+from .CommandStatus import CommandState
 
 
 class CommandHandler:

--- a/src/mccode_plumber/file_writer_control/InThreadStatusTracker.py
+++ b/src/mccode_plumber/file_writer_control/InThreadStatusTracker.py
@@ -22,14 +22,14 @@ from streaming_data_types.status_x5f2 import FILE_IDENTIFIER as STAT_IDENTIFIER
 from streaming_data_types.status_x5f2 import StatusMessage
 from streaming_data_types.utils import get_schema
 
-from file_writer_control.CommandStatus import CommandState, CommandStatus
-from file_writer_control.JobStatus import JobState, JobStatus
-from file_writer_control.StateExtractor import (
+from .CommandStatus import CommandState, CommandStatus
+from .JobStatus import JobState, JobStatus
+from .StateExtractor import (
     extract_job_state_from_answer,
     extract_state_from_command_answer,
     extract_worker_state_from_status,
 )
-from file_writer_control.WorkerStatus import WorkerState, WorkerStatus
+from .WorkerStatus import WorkerState, WorkerStatus
 
 DEAD_ENTITY_TIME_LIMIT = timedelta(hours=1)
 

--- a/src/mccode_plumber/file_writer_control/InThreadStatusTracker.py
+++ b/src/mccode_plumber/file_writer_control/InThreadStatusTracker.py
@@ -223,6 +223,6 @@ class InThreadStatusTracker:
             current_job.state = JobState.ERROR
         else:
             current_job.state = JobState.DONE
-            current_job.metadata = json.loads(stopped.metadata)
+            current_job.metadata = json.loads(stopped.metadata) if stopped.metadata is not None else None
         current_job.message = stopped.message
         self.known_workers[stopped.service_id].state = WorkerState.IDLE

--- a/src/mccode_plumber/file_writer_control/JobHandler.py
+++ b/src/mccode_plumber/file_writer_control/JobHandler.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 
-from file_writer_control.CommandHandler import CommandHandler
-from file_writer_control.JobStatus import JobState
-from file_writer_control.WorkerFinder import WorkerFinder
-from file_writer_control.WriteJob import WriteJob
+from .CommandHandler import CommandHandler
+from .JobStatus import JobState
+from .WorkerFinder import WorkerFinder
+from .WriteJob import WriteJob
 
 
 class JobHandler:

--- a/src/mccode_plumber/file_writer_control/StateExtractor.py
+++ b/src/mccode_plumber/file_writer_control/StateExtractor.py
@@ -8,9 +8,9 @@ from streaming_data_types.action_response_answ import (
 )
 from streaming_data_types.status_x5f2 import StatusMessage
 
-from file_writer_control.CommandStatus import CommandState
-from file_writer_control.JobStatus import JobState
-from file_writer_control.WorkerStatus import WorkerState
+from .CommandStatus import CommandState
+from .JobStatus import JobState
+from .WorkerStatus import WorkerState
 
 
 def extract_worker_state_from_status(status: StatusMessage) -> WorkerState:

--- a/src/mccode_plumber/file_writer_control/WorkerFinder.py
+++ b/src/mccode_plumber/file_writer_control/WorkerFinder.py
@@ -6,13 +6,13 @@ from kafka import KafkaProducer
 from kafka.errors import NoBrokersAvailable
 from streaming_data_types.run_stop_6s4t import serialise_6s4t as serialise_stop
 
-from file_writer_control.CommandChannel import CommandChannel
-from file_writer_control.CommandHandler import CommandHandler
-from file_writer_control.CommandStatus import CommandStatus
-from file_writer_control.JobStatus import JobState, JobStatus
-from file_writer_control.KafkaTopicUrl import KafkaTopicUrl
-from file_writer_control.WorkerStatus import WorkerStatus
-from file_writer_control.WriteJob import WriteJob
+from .CommandChannel import CommandChannel
+from .CommandHandler import CommandHandler
+from .CommandStatus import CommandStatus
+from .JobStatus import JobState, JobStatus
+from .KafkaTopicUrl import KafkaTopicUrl
+from .WorkerStatus import WorkerStatus
+from .WriteJob import WriteJob
 
 
 class WorkerFinderBase:

--- a/src/mccode_plumber/file_writer_control/WorkerJobPool.py
+++ b/src/mccode_plumber/file_writer_control/WorkerJobPool.py
@@ -3,11 +3,11 @@ from typing import Dict
 from kafka import KafkaProducer
 from kafka.errors import NoBrokersAvailable
 
-from file_writer_control.CommandHandler import CommandHandler
-from file_writer_control.CommandStatus import CommandState
-from file_writer_control.KafkaTopicUrl import KafkaTopicUrl
-from file_writer_control.WorkerFinder import WorkerFinder
-from file_writer_control.WriteJob import WriteJob
+from .CommandHandler import CommandHandler
+from .CommandStatus import CommandState
+from .KafkaTopicUrl import KafkaTopicUrl
+from .WorkerFinder import WorkerFinder
+from .WriteJob import WriteJob
 
 
 class WorkerJobPool(WorkerFinder):

--- a/src/mccode_plumber/writer.py
+++ b/src/mccode_plumber/writer.py
@@ -334,3 +334,84 @@ def wait_on_writer():
         # raise RuntimeError(e.__str__() + f" The message was: {stop.get_message()}")
         exit(EX_UNAVAILABLE)
     exit(EX_OK)
+
+
+def kill_job():
+    import time
+    from argparse import ArgumentParser
+    from .file_writer_control import WorkerJobPool
+    parser = ArgumentParser()
+    parser.add_argument('-b', '--broker', help="Kafka broker", default='localhost:9092', type=str)
+    parser.add_argument('-c', '--command', help="Writer command topic", default="WriterCommand", type=str)
+    parser.add_argument('-t', '--topic', help='Writer job topic', default='WriterJobs', type=str)
+    parser.add_argument('-s', '--sleep', help='Post pool creation sleep time (s)', default=1, type=int)
+    parser.add_argument('service_id', type=str, help='Writer service id to stop')
+    parser.add_argument('job_id', type=str, help='Writer job id to stop')
+
+    args = parser.parse_args()
+    pool = WorkerJobPool(f'{args.broker}/{args.topic}', f'{args.broker}/{args.command}')
+    time.sleep(args.sleep)
+    pool.try_send_stop_now(args.service_id, args.job_id)
+
+
+def list_status():
+    import time
+    from .file_writer_control import WorkerJobPool
+    from argparse import ArgumentParser
+    parser = ArgumentParser()
+    parser.add_argument('-b', '--broker', help="Kafka broker", default='localhost:9092', type=str)
+    parser.add_argument('-c', '--command', help="Writer command topic", default="WriterCommand", type=str)
+    parser.add_argument('-t', '--topic', help='Writer job topic', default='WriterJobs', type=str)
+    parser.add_argument('-s', '--sleep', type=int, help='Post pool creation sleep time', default=1)
+    args = parser.parse_args()
+    pool = WorkerJobPool(f'{args.broker}/{args.topic}', f'{args.broker}/{args.command}')
+    time.sleep(args.sleep)
+
+    def print_columns(titles: list | tuple,
+                      values: list[list | tuple] | tuple[list | tuple, ...]):
+        if not len(values) or not len(titles):
+            return
+        widths = [len(str(x)) for x in titles]
+        for row in values:
+            for i, v in enumerate(row):
+                n = len(str(v))
+                if n > widths[i]:
+                    widths[i] = n
+        w_format = ''.join([f'{{:{n + 1:d}s}}' for n in widths])
+        print(w_format.format(*[str(x) for x in titles]))
+        print(w_format.format(*['-' * n for n in widths]))
+        for row in values:
+            print(w_format.format(*[str(x) for x in row]))
+        print()
+
+    def print_current_state(channel: WorkerJobPool):
+        workers = channel.list_known_workers()
+        if len(workers):
+            print("Known workers")
+            print_columns(("Service id", "Current state"),
+                          [(w.service_id, w.state) for w in workers])
+        else:
+            print("No workers")
+
+        jobs = channel.list_known_jobs()
+        if len(jobs):
+            print("Known jobs")
+            job_info = [(j.service_id, j.job_id, j.state,
+                         j.file_name if j.file_name else j.message) for j in jobs]
+            print_columns(
+                ("Service id", "Job id", "Current state", "File name or message"),
+                job_info)
+        else:
+            print("No jobs")
+
+        commands = channel.list_known_commands()
+        if len(commands):
+            print("Known commands")
+            print_columns(("Job id", "Command id", "Current state", "Message"),
+                          [(c.job_id, c.command_id, c.state, c.message) for c in
+                           commands])
+        else:
+            print("No commands")
+
+
+    print_current_state(pool)


### PR DESCRIPTION
As part of #9 the functionality of the captured module needed slight modification.

Also added are two entrypoint scripts to help with (nearly) gracefully handling of the failed simulation state where a filewriter job has been started, the simulation runtime has failed for some reason, and the writer continues to wait forever for streamed data. One script is a slight modification to a `file_writer_control` example to list idle and active writers, the second I proposed as an example there to immediately stop a job.
Their use follows the blueprint
```cmd
$ mp-writer-list -b localhost:9092
Known workers
Service id                              Current state       
--------------------------------------- ------------------- 
kafka-to-nexus:c67de856f764-pid:12-da21 WorkerState.WRITING 

Known jobs
Service id                              Job id                               Current state    File name or message       
--------------------------------------- ------------------------------------ ---------------- -------------------------- 
kafka-to-nexus:c67de856f764-pid:12-da21 2bb261b5-2962-45d1-a3b4-a1d796a7a463 JobState.WRITING file.h5 

No commands
$ mp-writer-kill -b localhost:9092 kafka-to-nexus:c67de856f764-pid:12-da21 2bb261b5-2962-45d1-a3b4-a1d796a7a463
$ mp-writer-list -b localhost:9092
Known workers
Service id                              Current state    
--------------------------------------- ---------------- 
kafka-to-nexus:c67de856f764-pid:12-da21 WorkerState.IDLE 

No jobs
No commands
```