### PR TITLE
[Add] version flag to entrypoints, delay loading mccode-antlr

### DIFF
--- a/src/mccode_plumber/__init__.py
+++ b/src/mccode_plumber/__init__.py
@@ -1,0 +1,6 @@
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version('mccode-plumber')
+except PackageNotFoundError:
+    pass

--- a/src/mccode_plumber/epics.py
+++ b/src/mccode_plumber/epics.py
@@ -53,9 +53,11 @@ class MailboxHandler:
 
 def get_parser():
     from argparse import ArgumentParser
+    from mccode_plumber import __version__
     p = ArgumentParser()
     p.add_argument('instr', type=str, help='The instrument file to read')
     p.add_argument('-p', '--prefix', type=str, help='The EPICS PV prefix to use', default='mcstas:')
+    p.add_argument('-v', '--version', action='version', version=__version__)
     return p
 
 

--- a/src/mccode_plumber/forwarder.py
+++ b/src/mccode_plumber/forwarder.py
@@ -62,12 +62,14 @@ def reset_forwarder(pvs: list[dict], config=None, prefix=None, topic=None):
 def parse_registrar_args():
     from argparse import ArgumentParser
     from .mccode import get_mccode_instr_parameters
+    from mccode_plumber import __version__
 
     parser = ArgumentParser(description="Discover EPICS PVs and inform a forwarder about them")
     parser.add_argument('-p', '--prefix', type=str, default='mcstas:')
     parser.add_argument('instrument', type=str, help="The mcstas instrument with EPICS PVs")
     parser.add_argument('-c', '--config', type=str, help="The Kafka server and topic for configuring the Forwarder")
     parser.add_argument('-t', '--topic', type=str, help="The Kafka topic to instruct the Forwarder to send data to")
+    parser.add_argument('-v', '--version', action='version', version=__version__)
 
     args = parser.parse_args()
     parameter_names = [p.name for p in get_mccode_instr_parameters(args.instrument)]

--- a/src/mccode_plumber/kafka.py
+++ b/src/mccode_plumber/kafka.py
@@ -1,9 +1,11 @@
 def parse_kafka_topic_args():
     from argparse import ArgumentParser
+    from mccode_plumber import __version__
     parser = ArgumentParser(description="Prepare the named Kafka broker to host one or more topics")
     parser.add_argument('-b', '--broker', type=str, help='The Kafka broker server to interact with')
     parser.add_argument('topic', nargs="+", type=str, help='The Kafka topic(s) to register')
     parser.add_argument('-q', '--quiet', action='store_true', help='Quiet (positive) failure')
+    parser.add_argument('-v', '--version', action='version', version=__version__)
 
     args = parser.parse_args()
     return args

--- a/src/mccode_plumber/mccode.py
+++ b/src/mccode_plumber/mccode.py
@@ -1,15 +1,13 @@
 from pathlib import Path
 from typing import Union
-from mccode_antlr.instr import Instr
-from mccode_antlr.common import InstrumentParameter
 
 
-def get_mcstas_instr(filename: Union[Path, str]) -> Instr:
+def get_mcstas_instr(filename: Union[Path, str]):
     from restage.instr import load_instr
     return load_instr(filename)
 
 
-def get_mccode_instr_parameters(filename: Union[Path, str]) -> tuple[InstrumentParameter]:
+def get_mccode_instr_parameters(filename: Union[Path, str]):
     from mccode_antlr.loader.loader import parse_mccode_instr_parameters
     if not isinstance(filename, Path):
         filename = Path(filename)
@@ -42,12 +40,14 @@ def insert_mcstas_hdf5(filename: Union[Path, str], outfile: Union[Path, str], pa
 
 def get_arg_parser():
     from argparse import ArgumentParser
+    from mccode_plumber import __version__
     from .utils import is_readable, is_appendable
     parser = ArgumentParser(description="Copy a Instr HDF5 representation to a NeXus HDF5 file")
     a = parser.add_argument
     a('instrument', type=is_readable, default=None, help="The mcstas instrument file")
     a('-p', '--parent', type=str, default='mcstas')
     a('-o', '--outfile', type=is_appendable, default=None, help='Base NeXus structure, will be extended')
+    a('-v', '--version', action='version', version=__version__)
     return parser
 
 

--- a/src/mccode_plumber/splitrun.py
+++ b/src/mccode_plumber/splitrun.py
@@ -1,10 +1,12 @@
 def make_parser():
+    from mccode_plumber import __version__
     from restage.splitrun import make_splitrun_parser
     parser = make_splitrun_parser()
     parser.prog = 'mp-splitrun'
     parser.add_argument('--broker', type=str, help='The Kafka broker to send monitors to', default=None)
     parser.add_argument('--source', type=str, help='The Kafka source name to use for monitors', default=None)
     parser.add_argument('--topic', type=str, help='The Kafka topic name(s) to use for monitors', default=None, action='append')
+    parser.add_argument('-v', '--version', action='version', version=__version__)
     return parser
 
 


### PR DESCRIPTION
Allow the command line entrypoints to return the installed `mccode-plumber` version. 

Functions using parts of `mccode-antlr` delay loading any of that module in order to (hopefully) support installing and testing `mccode-plumber` _inside_ of an Apptainer, where the container filesystem at test-time is read only but running processes gain access to the host filesystem at runtime.
This prevents loading any part of the `mccode_antlr` Python module during Apptainer testing since its use of `confuse` and `pooch` does not work on a read-only filesystem.