### PR TITLE
Add managed services entrypoint and orchestrated `splitrun` for NeXus file output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ mp-writer-kill = 'mccode_plumber.writer:kill_job'
 mp-writer-killall = 'mccode_plumber.writer:kill_all'
 mp-register-topics = 'mccode_plumber.kafka:register_topics'
 mp-insert-hdf5-instr = 'mccode_plumber.mccode:insert'
+mp-splitrun-nexus = 'mccode_plumber.manage.orchestrate:main'
 
 [tool.setuptools_scm]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     'p4p',
     'kafka-python>=2.2.11',
     'ess-streaming-data-types>=0.14.0',
-    'restage>=0.7.1',
+    'restage>=0.7.2',
     'mccode-to-kafka>=0.2.2',
     'moreniius>=0.4.0',
     'icecream',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ mp-writer-killall = 'mccode_plumber.writer:kill_all'
 mp-register-topics = 'mccode_plumber.kafka:register_topics'
 mp-insert-hdf5-instr = 'mccode_plumber.mccode:insert'
 mp-nexus-splitrun = 'mccode_plumber.manage.orchestrate:main'
-mp-nexus-waiter = 'mccode_plumber.manage.orchestrate:waiter'
+mp-nexus-services = 'mccode_plumber.manage.orchestrate:services'
 
 [tool.setuptools_scm]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     'mccode-to-kafka>=0.2.2',
     'moreniius>=0.4.0',
     'icecream',
+    'ephemeral-port-reserve',
 ]
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ mp-writer-kill = 'mccode_plumber.writer:kill_job'
 mp-writer-killall = 'mccode_plumber.writer:kill_all'
 mp-register-topics = 'mccode_plumber.kafka:register_topics'
 mp-insert-hdf5-instr = 'mccode_plumber.mccode:insert'
-mp-splitrun-nexus = 'mccode_plumber.manage.orchestrate:main'
+mp-nexus-splitrun = 'mccode_plumber.manage.orchestrate:main'
+mp-nexus-waiter = 'mccode_plumber.manage.orchestrate:waiter'
 
 [tool.setuptools_scm]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dynamic = ['version']
 [project.scripts]
 mp-splitrun = 'mccode_plumber.splitrun:main'
 mp-epics = 'mccode_plumber.epics:run'
+mp-epics-strings = 'mccode_plumber.epics:run_strings'
 mp-epics-update = 'mccode_plumber.epics:update'
 mp-forwarder-setup = 'mccode_plumber.forwarder:setup'
 mp-forwarder-teardown = 'mccode_plumber.forwarder:teardown'

--- a/src/mccode_plumber/epics.py
+++ b/src/mccode_plumber/epics.py
@@ -74,7 +74,6 @@ def main(names: dict[str, NTScalar], prefix: str = None):
     for name, value in names.items():
         pv = SharedPV(initial=value, handler=MailboxHandler())
         provider.add(f'{prefix}{name}' if prefix else name, pv)
-        print(f'Add mailbox for {prefix}{name}')
         pvs.append(pv)
 
     print(f'Start mailbox server for {len(pvs)} PVs with prefix {prefix}')

--- a/src/mccode_plumber/epics.py
+++ b/src/mccode_plumber/epics.py
@@ -5,10 +5,9 @@ from p4p.server.thread import SharedPV
 from pathlib import Path
 from typing import Union
 
-
-def convert_instr_parameters_to_nt(parameters):
+def instr_par_to_nt_primitive(parameters):
     from mccode_antlr.common.expression import DataType, ShapeType
-    out = {}
+    out = []
     for p in parameters:
         expr = p.value
         if expr.is_str:
@@ -21,7 +20,37 @@ def convert_instr_parameters_to_nt(parameters):
             raise ValueError(f"Unknown parameter type {expr.data_type}")
         if expr.shape_type == ShapeType.vector:
             t, d = 'a' + t, [d]
-        out[p.name] = NTScalar(t).wrap(expr.value if expr.has_value else d)
+        out.append((p.name, t, d))
+    return out
+
+def instr_par_nt_to_strings(parameters):
+    return [f'{n}:{t}:{d}'.replace(' ','') for n, t, d in instr_par_to_nt_primitive(parameters)]
+
+def strings_to_instr_par_nt(strings):
+    out = []
+    for string in strings:
+        name, t, dstr = string.split(':')
+        trans = None
+        if 'i' in t:
+            trans = int
+        elif 'd' in t:
+            trans = float
+        elif 's' in t:
+            trans = str
+        else:
+            ValueError(f"Unknown type in {string}")
+        if t.startswith('a'):
+            d = [trans(x) for x in dstr.translate(str.maketrans(',',' ','[]')).split()]
+        else:
+            d = trans(dstr)
+        out.append((name, t, d))
+    return out
+
+def convert_strings_to_nt(strings):
+    return {n: NTScalar(t).wrap(d) for n, t, d in strings_to_instr_par_nt(strings)}
+
+def convert_instr_parameters_to_nt(parameters):
+    out = {n: NTScalar(t).wrap(d) for n, t, d in instr_par_to_nt_primitive(parameters)}
     return out
 
 
@@ -135,6 +164,22 @@ def update():
             raise ValueError(f'Address {address} has unknown type {type(pv)}')
 
     ctx.disconnect()
+
+
+def get_strings_parser():
+    from argparse import ArgumentParser
+    from mccode_plumber import __version__
+    p = ArgumentParser()
+    p.add_argument('strings', type=str, nargs='+', help='The string encoded NTScalars to read, each name:type-char:default')
+    p.add_argument('-p', '--prefix', type=str, help='The EPICS PV prefix to use', default='mcstas:')
+    p.add_argument('-v', '--version', action='version', version=__version__)
+    return p
+
+
+def run_strings():
+    args = get_strings_parser().parse_args()
+    main(convert_strings_to_nt(args.strings), prefix=args.prefix)
+
 
 
 if __name__ == '__main__':

--- a/src/mccode_plumber/epics.py
+++ b/src/mccode_plumber/epics.py
@@ -67,8 +67,11 @@ def parse_args():
     return parameters, args
 
 
-def main(names: dict[str, NTScalar], prefix: str = None):
+def main(names: dict[str, NTScalar], prefix: str = None, filename_required: bool = True):
     provider = StaticProvider('mailbox')  # 'mailbox' is an arbitrary name
+
+    if filename_required and 'mcpl_filename' not in names:
+        names['mcpl_filename'] = NTScalar('s').wrap('')
 
     pvs = []  # we must keep a reference in order to keep the Handler from being collected
     for name, value in names.items():

--- a/src/mccode_plumber/file_writer_control/WorkerJobPool.py
+++ b/src/mccode_plumber/file_writer_control/WorkerJobPool.py
@@ -19,7 +19,7 @@ class WorkerJobPool(WorkerFinder):
         self,
         job_topic_url: str,
         command_topic_url: str,
-        max_message_size: int = 1048576 * 200,
+        max_message_size: int = 104857600, # matching the default for Kafka -- previously was 2x larger
         kafka_config: Dict[str, str] = {},
     ):
         """
@@ -61,10 +61,15 @@ class WorkerJobPool(WorkerFinder):
         """
         See base class for documentation.
         """
+        print("Add job_id to command_channel")
         self.command_channel.add_job_id(job.job_id)
+        print("Add command_id to command_channel")
         self.command_channel.add_command_id(job.job_id, job.job_id)
+        print("Set command state to command_channel as WAITING_RESPONSE")
         self.command_channel.get_command(
             job.job_id
         ).state = CommandState.WAITING_RESPONSE
+        print(f"Send start message to pool")
         self._send_pool_message(job.get_start_message())
+        print("Return CommandHandler class")
         return CommandHandler(self.command_channel, job.job_id)

--- a/src/mccode_plumber/file_writer_control/WorkerJobPool.py
+++ b/src/mccode_plumber/file_writer_control/WorkerJobPool.py
@@ -61,15 +61,10 @@ class WorkerJobPool(WorkerFinder):
         """
         See base class for documentation.
         """
-        print("Add job_id to command_channel")
         self.command_channel.add_job_id(job.job_id)
-        print("Add command_id to command_channel")
         self.command_channel.add_command_id(job.job_id, job.job_id)
-        print("Set command state to command_channel as WAITING_RESPONSE")
         self.command_channel.get_command(
             job.job_id
         ).state = CommandState.WAITING_RESPONSE
-        print(f"Send start message to pool")
         self._send_pool_message(job.get_start_message())
-        print("Return CommandHandler class")
         return CommandHandler(self.command_channel, job.job_id)

--- a/src/mccode_plumber/forwarder.py
+++ b/src/mccode_plumber/forwarder.py
@@ -59,6 +59,15 @@ def reset_forwarder(pvs: list[dict], config=None, prefix=None, topic=None):
     return pvs
 
 
+def forwarder_partial_streams(prefix, topic, parameters):
+    names = [p.name for p in parameters]
+    if 'mcpl_filename' not in names:
+        names.append("mcpl_filename")
+    # Minimal information used by the forwarder for stream setup:
+    partial = [dict(source=f'{prefix}{n}', module='f144', topic=topic) for n in names]
+    return partial
+
+
 def parse_registrar_args():
     from argparse import ArgumentParser
     from .mccode import get_mccode_instr_parameters
@@ -72,11 +81,7 @@ def parse_registrar_args():
     parser.add_argument('-v', '--version', action='version', version=__version__)
 
     args = parser.parse_args()
-    parameter_names = [p.name for p in get_mccode_instr_parameters(args.instrument)]
-    if 'mcpl_filename' not in parameter_names:
-        parameter_names.append('mcpl_filename')
-    # the forwarder only cares about: "source", "module", "topic"
-    params = [{'source': f'{args.prefix}{name}', 'module': 'f144', 'topic': args.topic} for name in parameter_names]
+    params = forwarder_partial_streams(args.prefix, args.topic, get_mccode_instr_parameters(args.instrument))
     return params, args
 
 

--- a/src/mccode_plumber/kafka.py
+++ b/src/mccode_plumber/kafka.py
@@ -30,7 +30,16 @@ def parse_kafka_topic_args():
 def register_kafka_topics(broker: str, topics: list[str]):
     from confluent_kafka.admin import AdminClient, NewTopic
     client = AdminClient({"bootstrap.servers": broker})
-    new_ts = [NewTopic(t, num_partitions=1, replication_factor=1) for t in topics]
+    config = {
+        # 'cleanup.policy': 'delete',
+        # 'delete.retention.ms': 60000,
+        'max.message.bytes': 104857600,
+        # 'retention.bytes': 10737418240,
+        # 'retention.ms': 30000,
+        # 'segment.bytes': 104857600,
+        # 'segment.ms': 60000
+    }
+    new_ts = [NewTopic(t, num_partitions=1, replication_factor=1, config=config) for t in topics]
     futures = client.create_topics(new_ts)
     results = {}
     for topic, future in futures.items():

--- a/src/mccode_plumber/kafka.py
+++ b/src/mccode_plumber/kafka.py
@@ -1,3 +1,19 @@
+from enum import Enum
+
+
+class KafkaTopic(Enum):
+    CREATED = 1
+    EXISTS = 2
+    ERROR = 3
+    UNKNOWN = 4
+
+
+def all_exist(topic_enums):
+    if any(not isinstance(v, KafkaTopic) for v in topic_enums):
+        raise ValueError('Only KafkaTopic enumerated values supported')
+    return all(v == KafkaTopic.EXISTS or v == KafkaTopic.CREATED for v in topic_enums)
+
+
 def parse_kafka_topic_args():
     from argparse import ArgumentParser
     from mccode_plumber import __version__
@@ -11,19 +27,33 @@ def parse_kafka_topic_args():
     return args
 
 
-def register_topics():
+def register_kafka_topics(broker: str, topics: list[str]):
     from confluent_kafka.admin import AdminClient, NewTopic
-    args = parse_kafka_topic_args()
-
-    client = AdminClient({"bootstrap.servers": args.broker})
-    topics = [NewTopic(t, num_partitions=1, replication_factor=1) for t in args.topic]
-    futures = client.create_topics(topics)
-
+    client = AdminClient({"bootstrap.servers": broker})
+    new_ts = [NewTopic(t, num_partitions=1, replication_factor=1) for t in topics]
+    futures = client.create_topics(new_ts)
+    results = {}
     for topic, future in futures.items():
         try:
             future.result()
-            print(f"Topic {topic} created")
+            results[topic] = KafkaTopic.CREATED
         except Exception as e:
             from confluent_kafka.error import KafkaError
-            if not (args.quiet and e.args[0] == KafkaError.TOPIC_ALREADY_EXISTS):
-                print(f"Failed to create topic {topic}: {e.args[0].str()}")
+            if e.args[0] == KafkaError.TOPIC_ALREADY_EXISTS:
+                results[topic] = KafkaTopic.EXISTS
+            else:
+                results[topic] = e.args[0]
+    return results
+
+
+def register_topics():
+    args = parse_kafka_topic_args()
+    results = register_kafka_topics(args.broker, args.topic)
+    if not args.quiet:
+        for topic, result in results.items():
+            if result == KafkaTopic.CREATED:
+                print(f'Created topic {topic}')
+            elif result == KafkaTopic.EXISTS:
+                print(f'Topic {topic} already exists')
+            else:
+                print(f'Failed to register topic "{topic}"? {result}')

--- a/src/mccode_plumber/manage/__init__.py
+++ b/src/mccode_plumber/manage/__init__.py
@@ -1,3 +1,4 @@
+from .manager import Manager
 from .efu import EventFormationUnit
 from .epics import EPICSMailbox
 from .forwarder import Forwarder
@@ -10,6 +11,7 @@ from .ensure import (
 
 
 __all__ = (
+    "Manager",
     "EventFormationUnit",
     "EPICSMailbox",
     "Forwarder",

--- a/src/mccode_plumber/manage/__init__.py
+++ b/src/mccode_plumber/manage/__init__.py
@@ -2,6 +2,11 @@ from .efu import EventFormationUnit
 from .epics import EPICSMailbox
 from .forwarder import Forwarder
 from .writer import KafkaToNexus
+from .ensure import (
+    ensure_accessible_directory, ensure_accessible_file, ensure_executable,
+    ensure_readable_directory, ensure_readable_file,
+    ensure_writable_directory, ensure_writable_file
+)
 
 
 __all__ = (
@@ -9,4 +14,11 @@ __all__ = (
     "EPICSMailbox",
     "Forwarder",
     "KafkaToNexus",
+    "ensure_accessible_directory",
+    "ensure_accessible_file",
+    "ensure_executable",
+    "ensure_readable_directory",
+    "ensure_readable_file",
+    "ensure_writable_directory",
+    "ensure_writable_file",
 )

--- a/src/mccode_plumber/manage/__init__.py
+++ b/src/mccode_plumber/manage/__init__.py
@@ -1,0 +1,12 @@
+from .efu import EventFormationUnit
+from .epics import EPICSMailbox
+from .forwarder import Forwarder
+from .writer import KafkaToNexus
+
+
+__all__ = (
+    "EventFormationUnit",
+    "EPICSMailbox",
+    "Forwarder",
+    "KafkaToNexus",
+)

--- a/src/mccode_plumber/manage/efu.py
+++ b/src/mccode_plumber/manage/efu.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
-from mccode_plumber.manage.manager import Manager, ensure_path
+from mccode_plumber.manage.manager import Manager, ensure_readable_file, ensure_executable
 
 @dataclass
 class EventFormationUnit(Manager):
@@ -33,10 +33,9 @@ class EventFormationUnit(Manager):
     monitor_consecutive: int = 2
 
     def __post_init__(self):
-        from os import X_OK, R_OK
-        self.binary = ensure_path(self.binary, X_OK)
-        self.config = ensure_path(self.config, R_OK)
-        self.calibration = ensure_path(self.calibration, R_OK)
+        self.binary = ensure_executable(self.binary)
+        self.config = ensure_readable_file(self.config)
+        self.calibration = ensure_readable_file(self.calibration)
         if self.broker is None:
             self.broker = 'localhost:9092'
         if self.topic is None:

--- a/src/mccode_plumber/manage/efu.py
+++ b/src/mccode_plumber/manage/efu.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from mccode_plumber.manage.manager import Manager, ensure_path
 
 @dataclass
-class EventFormationUnitManager(Manager):
+class EventFormationUnit(Manager):
     """
     Command and control of an Event Formation Unit
 

--- a/src/mccode_plumber/manage/efu.py
+++ b/src/mccode_plumber/manage/efu.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 from ephemeral_port_reserve import reserve
-from mccode_plumber.manage.manager import Manager, ensure_readable_file, ensure_executable
+from .manager import Manager
+from .ensure import ensure_readable_file, ensure_executable
 
 @dataclass
 class EventFormationUnit(Manager):

--- a/src/mccode_plumber/manage/efu.py
+++ b/src/mccode_plumber/manage/efu.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from pathlib import Path
+from mccode_plumber.manage.manager import Manager, ensure_path
+
+@dataclass
+class EventFormationUnitManager(Manager):
+    """
+    Command and control of an Event Formation Unit
+
+    Properties
+    ----------
+    binary: the full path to a binary file which is the EFU
+    config: the full path to its configuration JSON file
+    calibration: the full path to its calibration JSON file
+    broker: the domain name or IP and port of the Kafka broker
+    topic: the EV44 detector data Kafka stream topic
+    samples_topic: the raw AR51 detector data Kafka stream topic
+    port: the UDP port at which the EFU will listen for Readout messages
+    command: the TCP port the EFU will use to listen for command messages, e.g. EXIT
+    monitor_every: For every `monitor_every`th Readout packet
+    monitor_consecutive: Send `monitor_consecutive` raw packets to `samples_topic`
+    """
+    binary: Path
+    config: Path
+    calibration: Path
+    broker: str | None = None
+    topic: str | None = None
+    samples_topic: str | None = None
+    port: int = 9000
+    command: int | None = None
+    monitor_every: int = 1000
+    monitor_consecutive: int = 2
+
+    def __post_init__(self):
+        from os import X_OK, R_OK
+        self.binary = ensure_path(self.binary, X_OK)
+        self.config = ensure_path(self.config, R_OK)
+        self.calibration = ensure_path(self.calibration, R_OK)
+        if self.broker is None:
+            self.broker = 'localhost:9092'
+        if self.topic is None:
+            self.topic = self.binary.stem
+        if self.samples_topic is None:
+            self.samples_topic = f'{self.topic}_samples'
+
+    def __run_command__(self):
+        from ephemeral_port_reserve import reserve
+        if self.command is None:
+            self.command = reserve()
+        argv = [self.binary,
+                '-b', self.broker,
+                '-t', self.topic,
+                '--ar51_topic', self.topic,
+                '--file', self.config,
+                '--calibration', self.calibration,
+                '--port', str(self.port),
+                '--cmdport', str(self.command),
+                '--monitor-every', str(self.monitor_every),
+                '--monitor-consecutive', str(self.monitor_consecutive),
+                '--nohwcheck']
+        return argv
+
+    def finalize(self):
+        import socket
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            try:
+                sock.connect(('localhost', self.command))
+                sock.sendall(bytes("EXIT\n", "utf-8"))
+                received = str(sock.recv(1024), "utf-8")
+            except ConnectionRefusedError:
+                # the server is already dead or was not started?
+                received = '<OK>'
+        if received != "<OK>":
+            print(
+                f"EFU responded with {received} when asked to exit. Check your system status manager whether it exited")

--- a/src/mccode_plumber/manage/efu.py
+++ b/src/mccode_plumber/manage/efu.py
@@ -46,16 +46,16 @@ class EventFormationUnit(Manager):
             self.samples_topic = f'{self.topic}_samples'
 
     def __run_command__(self):
-        argv = [self.binary,
+        argv = [self.binary.as_posix(),
                 '-b', self.broker,
                 '-t', self.topic,
-                '--ar51_topic', self.topic,
-                '--file', self.config,
-                '--calibration', self.calibration,
+                '--ar51_topic', self.samples_topic,
+                '--file', self.config.as_posix(),
+                '--calibration', self.calibration.as_posix(),
                 '--port', str(self.port),
                 '--cmdport', str(self.command),
-                '--monitor-every', str(self.monitor_every),
-                '--monitor-consecutive', str(self.monitor_consecutive),
+                '--monitor_every', str(self.monitor_every),
+                '--monitor_consecutive', str(self.monitor_consecutive),
                 '--nohwcheck']
         return argv
 

--- a/src/mccode_plumber/manage/ensure.py
+++ b/src/mccode_plumber/manage/ensure.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+from pathlib import Path
+from os import access, R_OK, W_OK, X_OK
+
+def message(mode) -> str:
+    return {R_OK: 'readable', W_OK: 'writable', X_OK: 'executable'}.get(mode, 'unknown')
+
+def ensure_executable(path: str| Path) -> Path:
+    from shutil import which
+    found = which(path)
+    if found is None:
+        raise FileNotFoundError(path)
+    return Path(found)
+
+def ensure_accessible_file(path: str| Path, mode, must_exist=True) -> Path:
+    if isinstance(path, str):
+        path = Path(path)
+    if not isinstance(path, Path):
+        raise ValueError(f'{path} is not a Path object')
+    if must_exist:
+        if not path.exists():
+            raise ValueError(f'{path} does not exist')
+        if not path.is_file():
+            raise ValueError(f'{path} is not a file')
+        if not access(path, mode):
+            raise ValueError(f'{path} is not {message(mode)}')
+    return path
+
+def ensure_accessible_directory(path: str| Path, mode) -> Path:
+    if isinstance(path, str):
+        path = Path(path)
+    if not isinstance(path, Path):
+        raise ValueError(f'{path} is not a Path object')
+    if not path.exists():
+        raise ValueError(f'{path} does not exist')
+    if not path.is_dir():
+        raise ValueError(f'{path} is not a directory')
+    if not access(path, mode):
+        raise ValueError(f'{path} is not a {message(mode)} directory')
+    return path
+
+def ensure_readable_file(path: str| Path) -> Path:
+    return ensure_accessible_file(path, R_OK)
+
+def ensure_writable_file(path: str| Path) -> Path:
+    return (
+            ensure_accessible_directory(path.parent, W_OK)
+            and ensure_accessible_file(path, W_OK, must_exist=False)
+    )
+
+def ensure_readable_directory(path: str| Path) -> Path:
+    return ensure_accessible_directory(path, R_OK)
+
+def ensure_writable_directory(path: str| Path) -> Path:
+    return ensure_accessible_directory(path, W_OK)
+
+
+def ensure_path(path: str| Path, access_type, is_dir: bool = False) -> Path:
+    if isinstance(path, str):
+        path = Path(path)
+    if not isinstance(path, Path):
+        raise ValueError(f'{path} is not a Path object')
+    if not path.exists():
+        raise ValueError(f'{path} does not exist')
+    if is_dir and not path.is_dir():
+        raise ValueError(f'{path} is not a directory')
+    if not is_dir and not path.is_file():
+        raise ValueError(f'{path} is not a file')
+    if not access(path, access_type):
+        raise ValueError(f'{path} does not support {access_type}')
+    return path

--- a/src/mccode_plumber/manage/ensure.py
+++ b/src/mccode_plumber/manage/ensure.py
@@ -43,6 +43,8 @@ def ensure_readable_file(path: str| Path) -> Path:
     return ensure_accessible_file(path, R_OK)
 
 def ensure_writable_file(path: str| Path) -> Path:
+    if not isinstance(path, Path):
+        path = Path(path)
     return (
             ensure_accessible_directory(path.parent, W_OK)
             and ensure_accessible_file(path, W_OK, must_exist=False)

--- a/src/mccode_plumber/manage/epics.py
+++ b/src/mccode_plumber/manage/epics.py
@@ -29,7 +29,7 @@ class EPICSMailbox(Manager):
             self.strings = instr_par_nt_to_strings(self.parameters)
 
     def __run_command__(self) -> list[str]:
-        return [self._command, '--prefix', self.prefix] + self.strings
+        return [self._command.as_posix(), '--prefix', self.prefix] + self.strings
 
     # @classmethod
     # def start(cls, capture: bool = True, **config):

--- a/src/mccode_plumber/manage/epics.py
+++ b/src/mccode_plumber/manage/epics.py
@@ -14,8 +14,9 @@ class EPICSMailbox(Manager):
     ----------
     parameters: the instrument parameters which define the PV values
     prefix:     a PV value prefix to use with all instrument-defined parameters
-    values:     optional dictionary of PV name: value pairs, if the instrument
-                is not to be used for determining which PVs should be used
+    strings:    optional list of NT parameter information to configure the
+                mailbox when the instrument parameters are not available for
+                use in determining the same information.
     """
     parameters: tuple[InstrumentParameter, ...]
     prefix: str
@@ -30,19 +31,3 @@ class EPICSMailbox(Manager):
 
     def __run_command__(self) -> list[str]:
         return [self._command.as_posix(), '--prefix', self.prefix] + self.strings
-
-    # @classmethod
-    # def start(cls, capture: bool = True, **config):
-    #     from multiprocessing import Process
-    #     from mccode_plumber.epics import main
-    #     names = cls.fieldnames()
-    #     kwargs = {k: config[k] for k in names if k in config}
-    #     obj = cls(**kwargs, _process=None)
-    #     obj._process = Process(target=main, args=(obj.values, obj.prefix))
-    #     obj._process.start()
-    #     return obj
-    #
-    # def stop(self):
-    #     self._process.terminate()
-    #     self._process.join(1)
-    #     self._process.close()

--- a/src/mccode_plumber/manage/epics.py
+++ b/src/mccode_plumber/manage/epics.py
@@ -31,7 +31,7 @@ class EPICSMailbox(Manager):
         from mccode_plumber.epics import main
         names = cls.fieldnames()
         kwargs = {k: config[k] for k in names if k in config}
-        obj = cls(**kwargs)
+        obj = cls(**kwargs, _process=None)
         obj._process = Process(target=main, args=(obj.values, obj.prefix))
         obj._process.start()
         return obj

--- a/src/mccode_plumber/manage/epics.py
+++ b/src/mccode_plumber/manage/epics.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 from mccode_antlr.common import InstrumentParameter
-from mccode_plumber.manage.manager import Manager, ensure_executable
+from .manager import Manager
+from .ensure import ensure_executable
 
 @dataclass
 class EPICSMailbox(Manager):

--- a/src/mccode_plumber/manage/epics.py
+++ b/src/mccode_plumber/manage/epics.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from p4p.nt import NTScalar
+
+from mccode_plumber.manage.manager import Manager
+
+@dataclass
+class EPICSMailboxManager(Manager):
+    """
+    Command and control of an EPICS Mailbox server for an instrument
+
+    Parameters
+    ----------
+    instrument: the instrument which defines the PV values
+    prefix:     a PV value prefix to use with all instrument-defined parameters
+    values:     optional dictionary of PV name: value pairs, if the instrument
+                is not to be used for determining which PVs should be used
+    """
+    instrument: Path | str
+    prefix: str | None = None
+    values: dict[str, NTScalar] = field(default_factory=dict)
+
+    def __post_init__(self):
+        from mccode_plumber.epics import parse_instr_nt_values
+        if not len(self.values):
+            self.values = parse_instr_nt_values(self.instrument)
+        self.prefix = self.prefix or "mcstas:"
+
+    @classmethod
+    def start(cls, capture: bool = True, **config):
+        """Find the EPICS parameters needed for the instrument and start a Mailbox server"""
+        from multiprocessing import Process
+        from mccode_plumber.epics import main
+        names = cls.fieldnames()
+        kwargs = {k: config[k] for k in names if k in config}
+        obj = cls(**kwargs)
+        obj._process = Process(target=main, args=(obj.values, obj.prefix))
+        obj._process.start()
+        return obj
+
+    def stop(self):
+        self._process.terminate()
+        self._process.join(1)
+        self._process.close()
+

--- a/src/mccode_plumber/manage/forwarder.py
+++ b/src/mccode_plumber/manage/forwarder.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from mccode_plumber.manage.manager import Manager, ensure_path
+
+
+@dataclass
+class ForwarderManager(Manager):
+    """
+    Manage the execution of a Forwarder to send EPICS PV updates to Kafka
+
+    Parameters
+    ----------
+    broker:     the name or address and port of the broker to which updated
+                EPICS values will be sent, once configured. (localhost:9092)
+    config:     the broker and topic used for configuring the forwarder
+                (localhost:9092/ForwardConfig)
+    status:     the broker and topic used for forwarder status messages
+                (localhost:9092/ForwardStatus)
+    retrieve:   Retrieve values from Kafka at configuration (False == don't)
+    verbosity:  Control if (Trace, Debug, Warning, Error, or Critical) messages
+                should be printed to STDOUT
+
+    Note
+    ----
+    `config` and `status` can be provided as _only_ their topic if they use the same
+    broker as PV updates. In such a case, there will be no '/' character in their input
+    value and `lambda value = f'{broker}/{value}'` will replace them.
+
+    """
+    broker: str | None = None
+    config: str | None = None
+    status: str | None = None
+    retrieve: bool = False
+    verbosity: str | None = None
+    forwarder_command: str = 'forwarder-launch'
+
+    def __post_init__(self):
+        from os import access, X_OK
+        from mccode_plumber.kafka import register_kafka_topics, all_exist
+        if not access(self.forwarder_command, X_OK):
+            raise ValueError(f'{self.forwarder_command} is not a valid command')
+        if self.broker is None:
+            self.broker = 'localhost:9092'
+        if self.config is None:
+            self.config = 'ForwardConfig'
+        if self.status is None:
+            self.status = 'ForwardStatus'
+        if '/' not in self.config:
+            self.config = f'{self.broker}/{self.config}'
+        if '/' not in self.status:
+            self.status = f'{self.broker}/{self.status}'
+
+        for broker_topic in (self.config, self.status):
+            b, t = broker_topic.split('/')
+            res = register_kafka_topics(b, [t])
+            if not all_exist(res.values()):
+                raise RuntimeError(f'Missing Kafka topics? {res}')
+
+
+    def __run_command__(self) -> list[str]:
+        args = [
+            self.forwarder_command,
+            '--config-topic', self.config,
+            '--status-topic', self.status,
+            '--output-broker', self.broker,
+        ]
+        if not self.retrieve:
+            args.append('--skip-retrieval')
+        if self.verbosity in ('Trace', 'Debug', 'Warning', 'Error', 'Critical'):
+            args.extend(['-v', self.verbosity])
+        return args

--- a/src/mccode_plumber/manage/forwarder.py
+++ b/src/mccode_plumber/manage/forwarder.py
@@ -4,7 +4,7 @@ from mccode_plumber.manage.manager import Manager, ensure_path
 
 
 @dataclass
-class ForwarderManager(Manager):
+class Forwarder(Manager):
     """
     Manage the execution of a Forwarder to send EPICS PV updates to Kafka
 

--- a/src/mccode_plumber/manage/forwarder.py
+++ b/src/mccode_plumber/manage/forwarder.py
@@ -59,7 +59,7 @@ class Forwarder(Manager):
 
     def __run_command__(self) -> list[str]:
         args = [
-            self._command,
+            self._command.as_posix(),
             '--config-topic', self.config,
             '--status-topic', self.status,
             '--output-broker', self.broker,

--- a/src/mccode_plumber/manage/forwarder.py
+++ b/src/mccode_plumber/manage/forwarder.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
-from mccode_plumber.manage.manager import Manager, ensure_executable
+from .manager import Manager
+from .ensure import ensure_executable
 
 
 @dataclass

--- a/src/mccode_plumber/manage/forwarder.py
+++ b/src/mccode_plumber/manage/forwarder.py
@@ -66,6 +66,14 @@ class Forwarder(Manager):
         ]
         if not self.retrieve:
             args.append('--skip-retrieval')
-        if self.verbosity in ('Trace', 'Debug', 'Warning', 'Error', 'Critical'):
-            args.extend(['-v', self.verbosity])
+        if (v:=forwarder_verbosity(self.verbosity)) is not None:
+            args.extend(['-v', v])
         return args
+
+
+def forwarder_verbosity(v):
+    if isinstance(v, str):
+        for k in ('Trace', 'Debug', 'Warning', 'Error', 'Critical'):
+            if k.lower() == v.lower():
+                return k
+    return None

--- a/src/mccode_plumber/manage/manager.py
+++ b/src/mccode_plumber/manage/manager.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from pathlib import Path
+from multiprocessing import Process
+
+
+def ensure_path(path: Path, access_type, is_dir: bool = False) -> Path:
+    from os import access
+    if isinstance(path, str):
+        path = Path(path)
+    if not isinstance(path, Path):
+        raise ValueError(f'{path} is not a Path object')
+    if not path.exists():
+        raise ValueError(f'{path} does not exist')
+    if is_dir and not path.is_dir():
+        raise ValueError(f'{path} is not a directory')
+    if not is_dir and not path.is_file():
+        raise ValueError(f'{path} is not a file')
+    if not access(path, access_type):
+        raise ValueError(f'{path} does not support {access_type}')
+    return path
+
+
+@dataclass
+class Manager:
+    """
+    Command and control of a process
+
+    Properties
+    ----------
+    _process:   a multiprocessing.Process instance, which is undefined for a short
+                period during instance creation inside the `start` class method
+    """
+    _process: Process | None
+
+    def __run_command__(self) -> list[str]:
+        pass
+
+    def run(self, capture=True):
+        from subprocess import run, STDOUT
+        root = Path(__file__).parent
+        argv = self.__run_command__()
+        if isinstance(capture, bool):
+            return run(argv, capture_output=capture, cwd=root, text=True)
+        else:
+            return run(argv, cwd=root, stdout=capture, stderr=STDOUT)
+
+    def finalize(self):
+        pass
+
+    @classmethod
+    def fieldnames(cls) -> list[str]:
+        from dataclasses import fields
+        return [field.name for field in fields(cls)]
+
+    @classmethod
+    def start(cls, capture=True, **config):
+        names = cls.fieldnames()
+        kwargs = {k: config[k] for k in names if k in config}
+        if any(k not in names for k in config):
+            raise ValueError(f'{config} expected to contain only {names}')
+        if '_process' not in kwargs:
+            kwargs['_process'] = None
+        manager = cls(**kwargs)
+        manager._process = Process(target=manager.run, args=(capture,))
+        manager._process.start()
+        return manager
+
+    def stop(self):
+        self.finalize()
+        self._process.terminate()

--- a/src/mccode_plumber/manage/manager.py
+++ b/src/mccode_plumber/manage/manager.py
@@ -87,14 +87,9 @@ class Manager:
         from subprocess import Popen, PIPE
         from select import select
         argv = self.__run_command__()
-        # root = Path(__file__).parent
-        # if isinstance(capture, bool):
-        #     return run(argv, capture_output=capture, cwd=root, text=True)
-        # else:
-        #     return run(argv, cwd=root, stdout=capture, stderr=STDOUT)
+
         shell = isinstance(argv, str)
         conn.send((IOType.stdout, f'Starting {argv if shell else " ".join(argv)}\n'))
-
         process = Popen(argv, shell=shell, stdout=PIPE, stderr=PIPE, bufsize=1, universal_newlines=True, )
         out, err = process.stdout.fileno(), process.stderr.fileno()
         check = [process.stdout, process.stderr]

--- a/src/mccode_plumber/manage/manager.py
+++ b/src/mccode_plumber/manage/manager.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
-from multiprocessing import Process
+from multiprocessing import Process, Pipe
+from multiprocessing.connection import Connection
+from enum import Enum
+from colorama import Fore, Back, Style
+
+class IOType(Enum):
+    stdout = 1
+    stderr = 2
 
 
 @dataclass
@@ -14,19 +21,13 @@ class Manager:
     _process:   a multiprocessing.Process instance, which is undefined for a short
                 period during instance creation inside the `start` class method
     """
+    name: str
+    style: Style
     _process: Process | None
+    _connection: Connection | None
 
     def __run_command__(self) -> list[str]:
         pass
-
-    def run(self, capture=True):
-        from subprocess import run, STDOUT
-        root = Path(__file__).parent
-        argv = self.__run_command__()
-        if isinstance(capture, bool):
-            return run(argv, capture_output=capture, cwd=root, text=True)
-        else:
-            return run(argv, cwd=root, stdout=capture, stderr=STDOUT)
 
     def finalize(self):
         pass
@@ -37,18 +38,81 @@ class Manager:
         return [field.name for field in fields(cls)]
 
     @classmethod
-    def start(cls, capture=True, **config):
+    def start(cls, **config):
         names = cls.fieldnames()
         kwargs = {k: config[k] for k in names if k in config}
         if any(k not in names for k in config):
             raise ValueError(f'{config} expected to contain only {names}')
         if '_process' not in kwargs:
             kwargs['_process'] = None
+        if '_connection' not in kwargs:
+            kwargs['_connection'] = None
+        if 'name' not in kwargs:
+            kwargs['name'] = 'Managed process'
+        if 'style' not in kwargs:
+            kwargs['style'] = Fore.WHITE + Back.BLACK
         manager = cls(**kwargs)
-        manager._process = Process(target=manager.run, args=(capture,))
+        manager._connection, child_conn = Pipe()
+        manager._process = Process(target=manager.run, args=(child_conn,))
         manager._process.start()
         return manager
 
     def stop(self):
         self.finalize()
         self._process.terminate()
+
+    def poll(self):
+        from sys import stderr
+        attn = Fore.BLACK + Back.RED + Style.BRIGHT
+        # check for anything received on our end of the connection
+        while self._connection.poll():
+            # examine what was returned:
+            try:
+                ret = self._connection.recv()
+            except EOFError:
+                print(f'{attn}{self.name}: [unexpected halt]{Style.RESET_ALL}')
+                return False
+            if len(ret) == 2:
+                t, line = ret
+                line = f'{self.style}{self.name}:{Style.RESET_ALL} {line}'
+                if t == IOType.stdout:
+                    print(line, end='')
+                else:
+                    print(line, file=stderr, end='')
+            else:
+                print(f'{attn}{self.name}: [unknown received data on connection]{Style.RESET_ALL}')
+        return self._process.is_alive()
+
+    def run(self, conn):
+        from subprocess import Popen, PIPE
+        from select import select
+        argv = self.__run_command__()
+        # root = Path(__file__).parent
+        # if isinstance(capture, bool):
+        #     return run(argv, capture_output=capture, cwd=root, text=True)
+        # else:
+        #     return run(argv, cwd=root, stdout=capture, stderr=STDOUT)
+        shell = isinstance(argv, str)
+        conn.send((IOType.stdout, f'Starting {argv if shell else " ".join(argv)}\n'))
+
+        process = Popen(argv, shell=shell, stdout=PIPE, stderr=PIPE, bufsize=1, universal_newlines=True, )
+        out, err = process.stdout.fileno(), process.stderr.fileno()
+        check = [process.stdout, process.stderr]
+        while process.poll() is None:
+            r, w, x = select(check, [], check, 0.5,)
+            for stream in r:
+                if stream.fileno() == out:
+                    conn.send((IOType.stdout, process.stdout.readline()))
+                elif stream.fileno() == err:
+                    conn.send((IOType.stderr, process.stderr.readline()))
+            for stream in x:
+                if stream.fileno() == out:
+                    conn.send((IOType.stdout, "EXCEPTION ON STDOUT"))
+                elif stream.fileno() == err:
+                    conn.send((IOType.stderr, "EXCEPTION ON STDERR"))
+        # Process finished, but the buffers may still contain data:
+        for stream in check:
+            if stream.fileno() == out:
+                map(lambda line: conn.send(IOType.stdout, line), stream.readlines())
+            elif stream.fileno() == err:
+                map(lambda line: conn.send(IOType.stderr, line), stream.readlines())

--- a/src/mccode_plumber/manage/manager.py
+++ b/src/mccode_plumber/manage/manager.py
@@ -4,59 +4,6 @@ from pathlib import Path
 from multiprocessing import Process
 
 
-def ensure_executable(path: Path):
-    from shutil import which
-    found = which(path)
-    if found is None:
-        raise FileNotFoundError(path)
-    return Path(found)
-
-def ensure_readable_file(path: Path):
-    from os import access, R_OK
-    if isinstance(path, str):
-        path = Path(path)
-    if not isinstance(path, Path):
-        raise ValueError(f'{path} is not a Path object')
-    if not path.exists():
-        raise ValueError(f'{path} does not exist')
-    if not path.is_file():
-        raise ValueError(f'{path} is not a file')
-    if not access(path, R_OK):
-        raise ValueError(f'{path} is not readable')
-    return path
-
-def ensure_writable_directory(path: Path):
-    from os import access, W_OK
-    if isinstance(path, str):
-        path = Path(path)
-    if not isinstance(path, Path):
-        raise ValueError(f'{path} is not a Path object')
-    if not path.exists():
-        raise ValueError(f'{path} does not exist')
-    if not path.is_dir():
-        raise ValueError(f'{path} is not a directory')
-    if not access(path, W_OK):
-        raise ValueError(f'{path} is not writable')
-    return path
-
-
-def ensure_path(path: Path, access_type, is_dir: bool = False) -> Path:
-    from os import access
-    if isinstance(path, str):
-        path = Path(path)
-    if not isinstance(path, Path):
-        raise ValueError(f'{path} is not a Path object')
-    if not path.exists():
-        raise ValueError(f'{path} does not exist')
-    if is_dir and not path.is_dir():
-        raise ValueError(f'{path} is not a directory')
-    if not is_dir and not path.is_file():
-        raise ValueError(f'{path} is not a file')
-    if not access(path, access_type):
-        raise ValueError(f'{path} does not support {access_type}')
-    return path
-
-
 @dataclass
 class Manager:
     """

--- a/src/mccode_plumber/manage/manager.py
+++ b/src/mccode_plumber/manage/manager.py
@@ -4,6 +4,42 @@ from pathlib import Path
 from multiprocessing import Process
 
 
+def ensure_executable(path: Path):
+    from shutil import which
+    found = which(path)
+    if found is None:
+        raise FileNotFoundError(path)
+    return Path(found)
+
+def ensure_readable_file(path: Path):
+    from os import access, R_OK
+    if isinstance(path, str):
+        path = Path(path)
+    if not isinstance(path, Path):
+        raise ValueError(f'{path} is not a Path object')
+    if not path.exists():
+        raise ValueError(f'{path} does not exist')
+    if not path.is_file():
+        raise ValueError(f'{path} is not a file')
+    if not access(path, R_OK):
+        raise ValueError(f'{path} is not readable')
+    return path
+
+def ensure_writable_directory(path: Path):
+    from os import access, W_OK
+    if isinstance(path, str):
+        path = Path(path)
+    if not isinstance(path, Path):
+        raise ValueError(f'{path} is not a Path object')
+    if not path.exists():
+        raise ValueError(f'{path} does not exist')
+    if not path.is_dir():
+        raise ValueError(f'{path} is not a directory')
+    if not access(path, W_OK):
+        raise ValueError(f'{path} is not writable')
+    return path
+
+
 def ensure_path(path: Path, access_type, is_dir: bool = False) -> Path:
     from os import access
     if isinstance(path, str):

--- a/src/mccode_plumber/manage/orchestrate.py
+++ b/src/mccode_plumber/manage/orchestrate.py
@@ -2,28 +2,19 @@ from __future__ import annotations
 
 from pathlib import Path
 from mccode_antlr.instr import Instr
-
+from mccode_plumber.manage.manager import ensure_readable_file, ensure_executable
 
 def guess_instr_config(name: str):
-    from os import access, R_OK
     guess = f'/event-formation-unit/configs/{name}/configs/{name}.json'
-    if access(guess, R_OK):
-        return guess
-    raise FileNotFoundError(f'Could not find {guess} in {name}')
+    return ensure_readable_file(Path(guess))
 
 def guess_instr_calibration(name: str):
-    from os import access, R_OK
     guess = f'/event-formation-unit/configs/{name}/configs/{name}nullcalib.json'
-    if access(guess, R_OK):
-        return guess
-    raise FileNotFoundError(f'Could not find {guess} in {name}')
+    return ensure_readable_file(Path(guess))
 
 def guess_instr_efu(name: str):
-    from os import access, X_OK
     guess = name.split('_')[0].split('.')[0].split('-')[0].lower()
-    if access(guess, X_OK):
-        return guess
-    raise FileNotFoundError(f'Could not find {guess} in {name}')
+    return ensure_executable(Path(guess))
 
 
 def register_topics(broker: str, topics: list[str]):

--- a/src/mccode_plumber/manage/orchestrate.py
+++ b/src/mccode_plumber/manage/orchestrate.py
@@ -1,0 +1,123 @@
+from pathlib import Path
+from mccode_antlr.instr import Instr
+from mccode_plumber.kafka import register_kafka_topics, all_exist
+from mccode_plumber.splitrun import make_parser
+
+def guess_instr_config(name: str):
+    from os import access, R_OK
+    guess = f'/event-formation-unit/configs/{name}/configs/{name}.json'
+    if access(guess, R_OK):
+        return guess
+    raise FileNotFoundError(f'Could not find {guess} in {name}')
+
+def guess_instr_calibration(name: str):
+    from os import access, R_OK
+    guess = f'/event-formation-unit/configs/{name}/configs/{name}nullcalib.json'
+    if access(guess, R_OK):
+        return guess
+    raise FileNotFoundError(f'Could not find {guess} in {name}')
+
+
+def get_topics(data: dict):
+    topics = set()
+    for k, v in data.items():
+        if isinstance(v, dict):
+            topics.update(get_topics(v))
+        elif k == 'topic':
+            topics.add(v)
+    return topics
+
+
+def conduct(instr: Instr, args, dump_structure=False):
+    from datetime import datetime, timezone
+    from mccode_plumber.epics import convert_instr_parameters_to_nt
+    from .efu import EventFormationUnitManager
+    from .epics import EPICSMailboxManager
+    from .forwarder import ForwarderManager
+    from .writer import WriterManager
+
+    now = datetime.now(timezone.utc).isoformat(timespec='seconds').split('+')[0]
+    params = {
+        'broker': 'localhost:9092',
+        'work': Path().resolve(),
+        'config': 'ForwardConfig',
+        'status': 'ForwardStatus',
+        'prefix': 'mcstas:',
+        'command': 'WriterCommand',
+        'job': 'WriterJob',
+        'event_source': f'{instr.name}_detector',
+        'event_topic': 'SimulatedEvents',
+        'parameter_topic': 'SimulatedParameters',
+        'title': f'{instr.name} simulation {now}: {args}',
+        'filename': f'{instr.name}_{now}.h5',
+        'origin': 'sample_stack',
+        'monitor_source': 'mccode-to-kafka',
+    }
+    if (structure := params['work'] / f'{instr.name}.json').exists():
+        params['structure_file'] = structure
+    if dump_structure:
+        params['structure_dump'] = params['work'] / f'{instr.name}.dump.json'
+
+    # Start up services
+    efu = EventFormationUnitManager.start(
+        binary=instr.name,
+        config=args.config or guess_instr_config(name=instr.name),
+        calibration=args.calibration or guess_instr_calibration(name=instr.name),
+        broker=params['broker'],
+        topic=params['event_topic'],
+    )
+    forwarder = ForwarderManager.start(
+        broker=params['broker'],
+        config=params['config'],
+        status=params['status'],
+    )
+    epics = EPICSMailboxManager.start(
+        values=convert_instr_parameters_to_nt(instr.parameters),
+        prefix=params['prefix'],
+    )
+    writer = WriterManager.start(
+        broker=params['broker'],
+        work=params['work'],
+        command=params['command'],
+        jbo=params['job'],
+    )
+
+    # Configure topics:
+    to_register = [params['parameter_topic'], params['event_topic']]
+    # plus the da00 topics listed in the nexus structure json file:
+    if 'structure_file' in params:
+        from json import load
+        with open(params['structure_file']) as f:
+            topics = get_topics(load(f))
+        to_register.extend(topics)
+
+    res = register_kafka_topics(params['broker'], to_register)
+    if not all_exist(res.values()):
+        raise RuntimeError(f'Missing Kafka topics? {res}')
+
+    # Tell the forwarder what to forward
+    # FIXME mp-forwarder-setup instr --prefix epics_prefix --config broker/config --topic parameter_topic
+
+    # Create a file-writer job
+    # FIXME mp-writer-write instr --prefix epicx_prefix --broker broker --job job
+    #       --command command --topic parameter_topic --event-source event_source
+    #       --event-topic event-topic --title title --filename filename
+    #       --ns-file structure_File --start-time {now} --origin origin --job-id {uuid}
+
+    ### Do the actual simulation
+    # FIXME call main in mccode_plumber.splitrun
+
+    ### Wait for the file-writer to finish its job (possibly kill it)
+
+    ### De-register the forwarder topics (Don't bother since we're about to kill it)
+
+    ### Stop the services
+    epics.stop()
+    writer.stop()
+    forwarder.stop()
+    efu.stop()
+
+    ### Repack the resulting file into contiguous memory
+    ## Equivalent to `h5repack -l CONTI ${filename} ${filename}.pack && mv ${filename}.pack ${filename}`
+
+    ### Insert the HDF5 representation of the instrument into the file, just incase

--- a/src/mccode_plumber/manage/orchestrate.py
+++ b/src/mccode_plumber/manage/orchestrate.py
@@ -5,7 +5,17 @@ from datetime import datetime, timezone
 from mccode_antlr.common import InstrumentParameter
 from mccode_antlr.instr import Instr
 from mccode_plumber.manage import ensure_readable_file, ensure_writable_file, ensure_executable
+from mccode_plumber.manage.efu import EventFormationUnitConfig
 
+TOPICS = {
+    'parameter': 'SimulatedParameters',
+    'event': 'SimulatedEvents',
+    'config': 'ForwardConfig',
+    'status': 'ForwardStatus',
+    'command': 'WriterCommand',
+    'pool': 'WriterPool',
+}
+PREFIX = 'mcstas:'
 
 def guess_instr_config(name: str):
     guess = f'/event-formation-unit/configs/{name}/configs/{name}.json'
@@ -34,8 +44,6 @@ def augment_structure(
         parameters: tuple[InstrumentParameter,...],
         structure: dict,
         title: str,
-        prefix: str,
-        topic: str
 ):
     """Helper to add stream JSON entries for Instr parameters to a NexusStructure
 
@@ -47,64 +55,68 @@ def augment_structure(
         NexusStructure JSON representing the instrument
     title : str
         Informative string about the simulation, to be inserted in structure
-    prefix : str
-        EPICS prefix used to construct PV addresses from parameter names, this
-        is used here to construct the Kafka stream source as well
-    topic : str
-        the Kafka stream topic which will hold Forwarded PV updates
     """
     from mccode_plumber.writer import (
         add_title_to_nexus_structure,  add_pvs_to_nexus_structure,
         construct_writer_pv_dicts_from_parameters,
     )
-    pvs = construct_writer_pv_dicts_from_parameters(parameters, prefix, topic)
+    pvs = construct_writer_pv_dicts_from_parameters(parameters, PREFIX, TOPICS['parameter'])
     data = add_pvs_to_nexus_structure(structure, pvs)
     data = add_title_to_nexus_structure(data, title)
     return data
 
 
-def stop_writer(broker, job_topic, command_topic, job_id, timeout):
+def stop_writer(broker, job_id, timeout):
     from time import sleep
     from datetime import timedelta
     from mccode_plumber.file_writer_control import WorkerJobPool
     from mccode_plumber.file_writer_control.JobStatus import JobState
-    pool = WorkerJobPool(f'{broker}/{job_topic}', f'{broker}/{command_topic}')
-    sleep(timeout)
-    pool.try_send_stop_now(None, job_id)
-    state = pool.get_job_state(job_id)
-    give_up = datetime.now() + timedelta(seconds=timeout)
-    while state != JobState.DONE and state != JobState.ERROR and state != JobState.TIMEOUT and datetime.now() < give_up:
+    # The process is now told to switch to a 'control' topic, that is job-specific
+    # So we should send the stop-command there. This is the 'command_topic_url'?
+    def back_stop(job_topic, command_topic):
+        job_topic_url = f"{broker}/{job_topic}"
+        command_topic_url = f"{broker}/{command_topic}"
+        pool = WorkerJobPool(job_topic_url, command_topic_url)
         sleep(1)
+        pool.try_send_stop_now(None, job_id)
         state = pool.get_job_state(job_id)
-    print(f'Done trying to stop {job_id} -> {state}')
+        give_up = datetime.now() + timedelta(seconds=timeout)
+        while state != JobState.DONE and state != JobState.ERROR and state != JobState.TIMEOUT and datetime.now() < give_up:
+            sleep(1)
+            state = pool.get_job_state(job_id)
+        return state
+
+    jstate = back_stop(TOPICS['pool'], TOPICS['command'])
+    if jstate != JobState.DONE:
+        print(f'Done trying to stop {job_id} -> {jstate}')
 
 
 def start_writer(start_time: datetime,
                  structure: dict,
                  filename: Path,
                  broker: str,
-                 job_topic: str,
-                 command_topic: str,
                  timeout: float):
-    from uuid import uuid4
+    from uuid import uuid1
     from mccode_plumber.writer import writer_start
-    job_id = str(uuid4())
+    job_id = str(uuid1())
     success = False
+    name = filename.name
     try:
-        print(f"Starting {job_id} from {start_time} for {filename}")
+        print(f"Starting {job_id} from {start_time} for file {name} under kafka-to-nexus' working directory")
         start, handler = writer_start(
-            start_time.isoformat(), structure, filename=filename.as_posix(),
+            start_time.isoformat(), structure, filename=name,
             stop_time_string=None,
-            broker=broker, job_topic=job_topic, command_topic=command_topic,
+            broker=broker, job_topic=TOPICS['pool'], command_topic=TOPICS['command'],
+            control_topic=TOPICS['command'], # don't switch topics
             timeout=timeout, job_id=job_id, wait=False
         )
         # success = start.is_done() # this causes an infinite hang?
-        print(f"Message to start {job_id} sent")
+        success = True
     except RuntimeError as e:
         if job_id in str(e):
             # starting the job failed, so try to kill it
             print(f"Starting {job_id} failed! Error: {e}")
-            stop_writer(broker, job_topic, command_topic, job_id, timeout)
+            stop_writer(broker, job_id, timeout)
 
     return job_id, success
 
@@ -118,6 +130,7 @@ def get_topics_iter(data: list | tuple):
             topics.update(get_topics_iter(entry))
     return topics
 
+
 def get_topics_dict(data: dict):
     topics = set()
     for k, v in data.items():
@@ -128,6 +141,7 @@ def get_topics_dict(data: dict):
         elif k == 'topic':
             topics.add(v)
     return topics
+
 
 def get_topics_json(data: dict) -> list[str]:
     """Traverse a loaded JSON object and return the found list of topic names"""
@@ -160,18 +174,50 @@ def get_instr_name_and_parameters(file: str | Path):
     raise ValueError('Unsupported file extension')
 
 
+def efu_parameter(s: str):
+    if ':' in s:
+        # with any ':' we require fully specified
+        #  name:{name};binary:{binary};config:{config_path};calibration:{calibration_path};topic:{topic};port:{port}
+        # what about spaces? or windows-style paths with C:/...
+        return EventFormationUnitConfig.from_cli_str(s)
+    # otherwise, allow an abbreviated format utilizing guesses
+    # Expected format is now:
+    #       {efu_binary}[;{calibration/file}[;{config/file}]][;{port}]
+    # That is, if you specify --efu, you must give its binary path and should
+    # give its port. The calibration/file determines pixel calculations, so is more
+    # likely to be needed. Finally, the config file can also be supplied to change, e.g.,
+    # number of pixels or rings, etc.
+    parts = s.split(';')
+    data = {'topic': TOPICS['event'], 'port': 9000, 'binary': ensure_executable(parts[0]),}
+    data['name'] = data['binary'].stem
+
+    if len(parts) > 1 and (len(parts) > 2 or not parts[1].isnumeric()):
+        data['calibration'] = parts[1]
+    else:
+        data['calibration'] = guess_instr_calibration(data['name'])
+    if len(parts) > 2 and (len(parts) > 3 or not parts[2].isnumeric()):
+        data['config'] = parts[2]
+    else:
+        data['config'] = guess_instr_config(data['name'])
+    if len(parts) > 1 and parts[-1].isnumeric():
+        data['port'] = int(parts[-1])
+
+    return EventFormationUnitConfig.from_dict(data)
+
+
 def make_services_parser():
     from mccode_plumber import __version__
     from argparse import ArgumentParser
     parser = ArgumentParser('mp-nexus-services')
-    parser.add_argument('instrument', type=str, help='Instrument .instr or .h5 file')
-    parser.add_argument('-v', '--version', action='version', version=__version__)
+    a=parser.add_argument
+    a('instrument', type=str, help='Instrument .instr or .h5 file')
+    a('-v', '--version', action='version', version=__version__)
     # No need to specify the broker, or monitor source or topic names
-    parser.add_argument('--structure', type=str, default=None, help='NeXus Structure JSON path')
-    parser.add_argument('--efu', type=str, default=None, help='EFU binary path/name')
-    parser.add_argument('--config', type=str, default=None, help='EFU configuration JSON')
-    parser.add_argument('--calibration', type=str, default=None, help='EFU calibration JSON')
-    parser.add_argument('--writer-working-dir', type=str, default=None, help='Working directory for kafka-to-nexus')
+    a('-b', '--broker', type=str, default=None, help='Kafka broker for all services', metavar='address:port')
+    a('--efu', type=efu_parameter, action='append', default=None, help='Configuration of one EFU, repeatable', metavar='name;calibration;config;port')
+    a('--writer-working-dir', type=str, default=None, help='Working directory for kafka-to-nexus')
+    a('--writer-verbosity', type=str, default=None, help='Verbose output type (trace, debug, warning, error, critical)')
+    a('--forwarder-verbosity', type=str, default=None,  help='Verbose output type (trace, debug, warning, error, critical)')
     return parser
 
 
@@ -181,24 +227,24 @@ def services():
     kwargs = {
         'instr_name': instr_name,
         'instr_parameters': instr_parameters,
-        'broker': 'localhost:9092',
+        'broker': args.broker or 'localhost:9092',
         'efu': args.efu,
-        'config': args.config,
-        'calibration': args.calibration,
         'work': args.writer_working_dir,
+        'verbosity_writer': args.writer_verbosity,
+        'verbosity_forwarder': args.forwarder_verbosity,
     }
     load_in_wait_load_out(**kwargs)
 
 
 def load_in_wait_load_out(
-            instr_name: str,
-            instr_parameters: tuple[InstrumentParameter, ...],
-            broker: str,
-            efu: str | None = None,
-            config: str | None = None,
-            calibration: str | None = None,
-            work: str | None = None,
-            manage: bool = True,
+        instr_name: str,
+        instr_parameters: tuple[InstrumentParameter, ...],
+        broker: str,
+        efu: list[EventFormationUnitConfig] | None,
+        work: str | None = None,
+        manage: bool = True,
+        verbosity_writer: str | None = None,
+        verbosity_forwarder: str | None = None,
     ):
         import signal
         from time import sleep
@@ -206,53 +252,61 @@ def load_in_wait_load_out(
         from mccode_plumber.manage import (
             EventFormationUnit, EPICSMailbox, Forwarder, KafkaToNexus
         )
-
-        prefix = 'mcstas:'
-        topics = {
-            'parameter': 'SimulatedParameters',
-            'event': 'SimulatedEvents',
-            'config': 'ForwardConfig',
-            'status': 'ForwardStatus',
-            'command': 'WriterCommand',
-            'job': 'WriterJob',
-        }
+        from mccode_plumber.manage.forwarder import forwarder_verbosity
+        from mccode_plumber.manage.writer import writer_verbosity
 
         # Start up services if they should be managed locally
-        things = () if not manage else (
-            EventFormationUnit.start(
-                name='EFU',
-                style=Fore.BLUE,
-                binary=efu or guess_instr_efu(instr_name),
-                config=config or guess_instr_config(name=instr_name),
-                calibration=calibration or guess_instr_calibration(name=instr_name),
-                broker=broker,
-                topic=topics['event'],
-            ),
-            Forwarder.start(
-                name='FWD',
-                style=Fore.GREEN,
-                broker=broker,
-                config=topics['config'],
-                status=topics['status'],
-            ),
-            EPICSMailbox.start(
-                name='MBX',
-                style=Fore.YELLOW + Back.LIGHTCYAN_EX,
-                parameters=instr_parameters,
-                prefix=prefix,
-            ),
-            KafkaToNexus.start(
-                name='K2N',
-                style=Fore.RED + Style.DIM,
-                broker=broker,
-                work=work,
-                command=topics['command'],
-                job=topics['job'],
-            ),
-        )
+        if manage:
+            if efu is None:
+                data = {
+                    'name': instr_name,
+                    'binary': guess_instr_efu(instr_name),
+                    'config': guess_instr_config(name=instr_name),
+                    'calibration': guess_instr_calibration(name=instr_name),
+                    'topic': TOPICS['event'],
+                    'port': 9000
+                }
+                if any('port' in p.name for p in instr_parameters):
+                    from mccode_antlr.common.expression import DataType
+                    port_parameter = next(
+                        p for p in instr_parameters if 'port' in p.name)
+                    if port_parameter.value.has_value and port_parameter.value.data_type == DataType.int:
+                        # the instrument parameter has a default, which is an integer
+                        data['port'] = port_parameter.value.value
+                efu = [EventFormationUnitConfig.from_dict(data)]
+            things = tuple(
+                EventFormationUnit.start(
+                    style=Fore.BLUE, broker=broker, **x.to_dict()
+                ) for x in efu) + (
+                Forwarder.start(
+                    name='FWD',
+                    style=Fore.GREEN,
+                    broker=broker,
+                    config=TOPICS['config'],
+                    status=TOPICS['status'],
+                    verbosity=forwarder_verbosity(verbosity_forwarder),
+                ),
+                EPICSMailbox.start(
+                    name='MBX',
+                    style=Fore.YELLOW + Back.LIGHTCYAN_EX,
+                    parameters=instr_parameters,
+                    prefix=PREFIX,
+                ),
+                KafkaToNexus.start(
+                    name='K2N',
+                    style=Fore.RED + Style.DIM,
+                    broker=broker,
+                    work=work,
+                    command=TOPICS['command'],
+                    pool=TOPICS['pool'],
+                    verbosity=writer_verbosity(verbosity_writer),
+                ),
+            )
+        else:
+            things = ()
 
         # Ensure stream topics exist
-        register_topics(broker, list(topics.values()))
+        register_topics(broker, list(TOPICS.values()))
 
         def signal_handler(signum, frame):
             if signum == signal.SIGINT:
@@ -272,7 +326,7 @@ def load_in_wait_load_out(
         # signal.pause()
         while all(service.poll() for service in things):
             # Try to grab and print any updates
-            sleep(0.1)
+            sleep(0.01)
         # If we reach here, one or more service has _already_ stopped
         for service in things:
             if not service.poll():
@@ -336,56 +390,41 @@ def orchestrate(
     from mccode_plumber.forwarder import (
         forwarder_partial_streams, configure_forwarder, reset_forwarder
     )
-
-    # now = datetime.now(timezone.utc).isoformat(timespec='seconds').split('+')[0]
-    # TODO Verify that UTC is the right time to use for file-writer start/stop times
     now = datetime.now(timezone.utc)
-    prefix = 'mcstas:'
     title = f'{instr.name} simulation {now}: {splitrun_kwargs["args"]}'
+    # kafka-to-nexus will strip off the root part of this path and put the remaining
+    # location and filename under _its_ working directory.
+    # Since it doesn't seem to create missing folders, we need to ensure we only
+    # provide the file stem.
     filename = ensure_writable_file(nexus_file or f'{instr.name}_{now:%y%m%dT%H%M%S}.h5')
-    topics = {
-        'parameter': 'SimulatedParameters',
-        'config': 'ForwardConfig',
-        'command': 'WriterCommand',
-        'job': 'WriterJob',
-    }
 
     # Tell the forwarder what to forward
-    partial_streams = forwarder_partial_streams(prefix, topics['parameter'], instr.parameters)
-    forwarder_config = f"{broker}/{topics['config']}"
-    configure_forwarder(partial_streams, forwarder_config, prefix, topics['parameter'])
+    partial_streams = forwarder_partial_streams(PREFIX, TOPICS['parameter'], instr.parameters)
+    forwarder_config = f"{broker}/{TOPICS['config']}"
+    configure_forwarder(partial_streams, forwarder_config, PREFIX, TOPICS['parameter'])
 
     # Create a file-writer job
-    structure = augment_structure(instr.parameters, structure, title, prefix, topics['parameter'])
+    structure = augment_structure(instr.parameters, structure, title)
     if structure_out:
         from json import dump
         with open(structure_out, 'w') as f:
             dump(structure, f)
 
-    print("JSON NeXus Structure augmented")
-
-    job_id, success = start_writer(
-        now, structure, filename, broker, topics['job'], topics['command'], 60.0,
-    )
-
-    print("Writer job started")
-
-    # Do the actual simulation, calling into restage.splitrun after parsing,
-    # Using the provided callbacks to send monitor data to Kafka
-    splitrun_args(instr, **splitrun_kwargs)
-
-    print("Splitrun simulation finished")
-
+    job_id, success = start_writer(now, structure, filename, broker, 30.0)
+    if success:
+        print("Writer job started -- start the simulation")
+        # Do the actual simulation, calling into restage.splitrun after parsing,
+        # Using the provided callbacks to send monitor data to Kafka
+        splitrun_args(instr, **splitrun_kwargs)
+        print("Splitrun simulation finished -- informing file-writer to stop")
     # Wait for the file-writer to finish its job (possibly kill it)
-    stop_writer(broker, topics['job'], topics['command'], job_id, 2.0)
-
-    print("Writer job finished")
-
+    stop_writer(broker, job_id, 20.0)
     # De-register the forwarder topics
-    reset_forwarder(partial_streams, forwarder_config, prefix, topics['parameter'])
-
+    reset_forwarder(partial_streams, forwarder_config, PREFIX, TOPICS['parameter'])
     # Verify that the file has been written?
-    ensure_readable_file(filename)
-    print(f'Finished writing {filename}')
-
-
+    # This only works if the filewriter was stared in the same directory :(
+    # ensure_readable_file(filename)
+    if filename.exists():
+        print(f'Finished writing {filename}')
+    else:
+        print(f'{filename} not found, check file-writer working directory')

--- a/src/mccode_plumber/manage/orchestrate.py
+++ b/src/mccode_plumber/manage/orchestrate.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from mccode_antlr.instr import Instr
 
@@ -142,12 +144,11 @@ def get_topics(data: dict):
     return topics
 
 
-def load_structure_file(structure_file):
-    from os import access, R_OK
+def load_file_json(file: str | Path):
+    from mccode_plumber.manage.manager import ensure_readable_file
     from json import load
-    if not (structure_file.exists() and structure_file.is_file() and access(structure_file, R_OK)):
-        raise ValueError('You must provide a nexus-structure file')
-    with open(structure_file, 'r') as f:
+    file = ensure_readable_file(file)
+    with file.open('r') as f:
         return load(f)
 
 
@@ -176,7 +177,7 @@ def main():
     args, parameters, precision = parse_splitrun(make_parser())
     instr = get_mcstas_instr(args.instrument[0])
 
-    structure = load_structure_file(args.structure if args.structure else Path(args.instrument[0]).with_suffix('.json'))
+    structure = load_file_json(args.structure if args.structure else Path(args.instrument[0]).with_suffix('.json'))
     broker = 'localhost:9092'
     monitor_source = 'mccode-to-kafka'
     callback_topics = list(get_topics(structure))  # all structure-topics might be monitor topics?

--- a/src/mccode_plumber/manage/orchestrate.py
+++ b/src/mccode_plumber/manage/orchestrate.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
+
+from mccode_antlr.common import InstrumentParameter
 from mccode_antlr.instr import Instr
 from mccode_plumber.manage.manager import ensure_readable_file, ensure_executable
 
@@ -25,13 +27,19 @@ def register_topics(broker: str, topics: list[str]):
         raise RuntimeError(f'Missing Kafka topics? {res}')
 
 
-def configure_forwarder(instr: Instr, broker: str, config: str, prefix: str, topic: str):
+def configure_forwarder(
+        parameters: tuple[InstrumentParameter, ...],
+        broker: str,
+        config: str,
+        prefix: str,
+        topic: str
+):
     """Configure forwarder by sending a configuration broker ADD streams for parameters
 
     Parameters
     ----------
-    instr : Instr
-        the source of parameters to build stream information for
+    parameters: tuple[InstrumentParameter, ...]
+        the parameters to build stream information for
     broker : str
         the Kafka broker that hosts the configuration and topic streams
     config : str
@@ -44,38 +52,50 @@ def configure_forwarder(instr: Instr, broker: str, config: str, prefix: str, top
     from mccode_plumber.forwarder import (
         configure_forwarder as cf, forwarder_partial_streams as fps
     )
-    cf(fps(prefix, topic, instr.parameters), f'{broker}/{config}', prefix, topic)
+    cf(fps(prefix, topic, parameters), f'{broker}/{config}', prefix, topic)
 
 
-def deconfigure_forwarder(instr: Instr, broker: str, config: str, prefix: str, topic: str):
+def deconfigure_forwarder(
+        parameters: tuple[InstrumentParameter, ...],
+        broker: str,
+        config: str,
+        prefix: str,
+        topic: str
+):
     """Stop forwarder by sending a configuration broker REMOVE streams for parameters
 
-        Parameters
-        ----------
-        instr : Instr
-            the source of parameters to build stream information for
-        broker : str
-            the Kafka broker that hosts the configuration and topic streams
-        config : str
-            the configuration stream name
-        prefix : str
-            the prefix to add to the stream source name for each parameter
-        topic : str
-            the Kafka topic to which updates will no longer be sent, at the configuration broker
-        """
+    Parameters
+    ----------
+    parameters: tuple[InstrumentParameter, ...]
+        the parameters to build stream information for
+    broker : str
+        the Kafka broker that hosts the configuration and topic streams
+    config : str
+        the configuration stream name
+    prefix : str
+        the prefix to add to the stream source name for each parameter
+    topic : str
+        the Kafka topic to which updates will no longer be sent, at the configuration broker
+    """
     from mccode_plumber.forwarder import (
         reset_forwarder as rf, forwarder_partial_streams as fps
     )
-    rf(fps(prefix, topic, instr.parameters), f'{broker}/{config}', prefix, topic)
+    rf(fps(prefix, topic, parameters), f'{broker}/{config}', prefix, topic)
 
 
-def augment_structure(instr: Instr, structure: dict, title: str, prefix: str, topic: str):
+def augment_structure(
+        parameters: tuple[InstrumentParameter,...],
+        structure: dict,
+        title: str,
+        prefix: str,
+        topic: str
+):
     """Helper to add stream JSON entries for Instr parameters to a NexusStructure
 
     Parameters
     ----------
-    instr : Instr
-        Instrument which contains one or more runtime parameter
+    parameters : tuple[InstrumentParameter,...]
+        Instrument runtime parameters
     structure : dict
         NexusStructure JSON representing the instrument
     title : str
@@ -90,7 +110,7 @@ def augment_structure(instr: Instr, structure: dict, title: str, prefix: str, to
         add_title_to_nexus_structure,  add_pvs_to_nexus_structure,
         construct_writer_pv_dicts_from_parameters,
     )
-    pvs = construct_writer_pv_dicts_from_parameters(instr.parameters, prefix, topic)
+    pvs = construct_writer_pv_dicts_from_parameters(parameters, prefix, topic)
     data = add_pvs_to_nexus_structure(structure, pvs)
     data = add_title_to_nexus_structure(data, title)
     return data
@@ -149,35 +169,148 @@ def load_file_json(file: str | Path):
         return load(f)
 
 
-def make_parser():
-    from argparse import BooleanOptionalAction
+def get_instr_name_and_parameters(file):
+    if file.suffix == '.h5':
+        # Shortcut loading the whole Instr:
+        import h5py
+        from mccode_antlr.io.hdf5 import HDF5IO
+        with h5py.File(file, 'r', driver='core', backing_store=False) as f:
+            name = f.attrs['name']
+            parameters = HDF5IO.load(f['parameters'])
+        return name, parameters
+    elif file.suffix == '.instr':
+        # No shortcuts
+        from mccode_antlr.loader import load_mcstas_instr
+        instr = load_mcstas_instr(file)
+        return instr.name, instr.parameters
+
+    raise ValueError('Unsupported file extension')
+
+
+def make_waiter_parser():
+    from mccode_plumber import __version__
+    from argparse import ArgumentParser
+    parser = ArgumentParser('mp-nexus-waiter')
+    parser.add_argument('instrument', type=str, help='Instrument .instr or .h5 file')
+    parser.add_argument('-v', '--version', action='version', version=__version__)
+    # No need to specify the broker, or monitor source or topic names
+    parser.add_argument('--structure', type=str, default=None, help='NeXus Structure JSON path')
+    parser.add_argument('--efu', type=str, default=None, help='EFU binary path/name')
+    parser.add_argument('--config', type=str, default=None, help='EFU configuration JSON')
+    parser.add_argument('--calibration', type=str, default=None, help='EFU calibration JSON')
+    return parser
+
+
+def waiter():
+    args = make_waiter_parser().parse_args()
+    instr_name, instr_parameters = get_instr_name_and_parameters(args.instrument)
+    kwargs = {
+        'instr_name': instr_name,
+        'instr_parameters': instr_parameters,
+        'broker': 'localhost:9092',
+        'efu': args.efu,
+        'config': args.config,
+        'calibration': args.calibration,
+        'work': args.work,
+    }
+    load_in_wait_load_out(**kwargs)
+
+
+def load_in_wait_load_out(
+            instr_name: str,
+            instr_parameters: tuple[InstrumentParameter, ...],
+            broker: str,
+            efu: str = None,
+            config: str = None,
+            calibration: str = None,
+            work: str = None,
+            manage: bool = True,
+    ):
+        import signal
+        from mccode_plumber.manage import (
+            EventFormationUnit, EPICSMailbox, Forwarder, KafkaToNexus
+        )
+
+        prefix = 'mcstas:'
+        topics = {
+            'parameter': 'SimulatedParameters',
+            'event': 'SimulatedEvents',
+            'config': 'ForwardConfig',
+            'status': 'ForwardStatus',
+            'command': 'WriterCommand',
+            'job': 'WriterJob',
+        }
+
+        # Start up services if they should be managed locally
+        services = () if not manage else (
+            EventFormationUnit.start(
+                binary=efu or guess_instr_efu(instr_name),
+                config=config or guess_instr_config(name=instr_name),
+                calibration=calibration or guess_instr_calibration(name=instr_name),
+                broker=broker,
+                topic=topics['event'],
+            ),
+            Forwarder.start(
+                broker=broker,
+                config=topics['config'],
+                status=topics['status'],
+            ),
+            EPICSMailbox.start(
+                parameters=instr_parameters,
+                prefix=prefix,
+            ),
+            KafkaToNexus.start(
+                broker=broker,
+                work=work,
+                command=topics['command'],
+                job=topics['job'],
+            ),
+        )
+
+        # Ensure stream topics exist
+        register_topics(broker, list(topics.values()))
+
+        def signal_handler(signum, frame):
+            if signum == signal.SIGINT:
+                print('Done waiting, following SIGINT')
+                for service in services:
+                    service.stop()
+                exit(0)
+            else:
+                print(f'Received signal {signum}, ignoring')
+
+        signal.signal(signal.SIGINT, signal_handler)
+        print('Run `mp-nexus-splitrun` in another process now')
+        print('Press Ctrl+C to exit')
+        signal.pause()
+
+        # In another process, now call orchestrate ...
+
+
+def make_splitrun_nexus_parser():
     from mccode_plumber import __version__
     from restage.splitrun import make_splitrun_parser
     parser = make_splitrun_parser()
-    parser.prog = 'mp-splitrun-nexus'
+    parser.prog = 'mp-nexus-splitrun'
     parser.add_argument('-v' ,'--version', action='version', version=__version__)
     # No need to specify the broker, or monitor source or topic names
     parser.add_argument('--work', type=str, default=None, help='Working directory')
     parser.add_argument('--structure', type=str, default=None, help='NeXus Structure JSON path')
     parser.add_argument('--structure-out', type=str, default=None, help='Output configured structure JSON path')
-    parser.add_argument('--efu', type=str, default=None, help='EFU binary path/name')
-    parser.add_argument('--config', type=str, default=None, help='EFU configuration JSON')
-    parser.add_argument('--calibration', type=str, default=None, help='EFU calibration JSON')
-    parser.add_argument('--manage', action=BooleanOptionalAction, default=True, help='Manage services locally')
     return parser
-
 
 def main():
     from mccode_plumber.mccode import get_mcstas_instr
     from restage.splitrun import parse_splitrun
     from mccode_plumber.splitrun import monitors_to_kafka_callback_with_arguments
-    args, parameters, precision = parse_splitrun(make_parser())
+    args, parameters, precision = parse_splitrun(make_splitrun_nexus_parser())
     instr = get_mcstas_instr(args.instrument[0])
 
     structure = load_file_json(args.structure if args.structure else Path(args.instrument[0]).with_suffix('.json'))
     broker = 'localhost:9092'
     monitor_source = 'mccode-to-kafka'
     callback_topics = list(get_topics(structure))  # all structure-topics might be monitor topics?
+    register_topics(broker, callback_topics) # ensure the topics are known to Kafka
 
     callback, callback_args = monitors_to_kafka_callback_with_arguments(broker, monitor_source, callback_topics)
     splitrun_kwargs = {
@@ -185,79 +318,46 @@ def main():
         'callback': callback, 'callback_arguments': callback_args,
     }
     conduct_kwargs = {
-        'efu': args.efu, 'config': args.config, 'calibration': args.calibration,
-        'work': args.work, 'structure_out': args.structure_out, 'manage': args.manage,
+        'work': args.work, 'structure_out': args.structure_out
     }
     for k in list(conduct_kwargs.keys()) + ['structure']:
         delattr(args, k)
-    return conduct(instr, structure, broker, callback_topics, splitrun_kwargs, **conduct_kwargs)
+    return orchestrate(instr, structure, broker, splitrun_kwargs, **conduct_kwargs)
 
 
-def conduct(
+
+def orchestrate(
         instr: Instr,
         structure,
         broker: str,
-        callback_topics: list[str],
         splitrun_kwargs: dict,
-        efu: str = None,
-        config: str = None,
-        calibration: str = None,
         work: str = None,
         structure_out: str = None,
-        manage: bool = True,
 ):
     from datetime import datetime, timezone
     from restage.splitrun import splitrun_args
-    from mccode_plumber.manage import (EventFormationUnit, EPICSMailbox, Forwarder, KafkaToNexus)
+
+    if not isinstance(work, Path):
+        work = Path(work) if work else Path()
 
     # now = datetime.now(timezone.utc).isoformat(timespec='seconds').split('+')[0]
     # TODO Verify that UTC is the right time to use for file-writer start/stop times
     now = datetime.now(timezone.utc)
     prefix = 'mcstas:'
     title = f'{instr.name} simulation {now}: {splitrun_kwargs["args"]}'
-    filename = f'{instr.name}_{now:%y%m%dT%H%M%S}.h5'
+    filename = work.resolve() / f'{instr.name}_{now:%y%m%dT%H%M%S}.h5'
     topics = {
         'parameter': 'SimulatedParameters',
-        'event': 'SimulatedEvents',
         'config': 'ForwardConfig',
-        'status': 'ForwardStatus',
         'command': 'WriterCommand',
         'job': 'WriterJob',
     }
 
-    # Start up services if they should be managed locally
-    services = () if not manage else (
-        EventFormationUnit.start(
-            binary=efu or guess_instr_efu(instr.name),
-            config=config or guess_instr_config(name=instr.name),
-            calibration=calibration or guess_instr_calibration(name=instr.name),
-            broker=broker,
-            topic=topics['event'],
-        ),
-        Forwarder.start(
-            broker=broker,
-            config=topics['config'],
-            status=topics['status'],
-        ),
-        EPICSMailbox.start(
-            parameters=instr.parameters,
-            prefix=prefix,
-        ),
-        KafkaToNexus.start(
-            broker=broker,
-            work=work,
-            command=topics['command'],
-            job=topics['job'],
-        ),
-    )
-
-    # Ensure stream topics exist
-    register_topics(broker, list(topics.values()) + callback_topics)
     # Tell the forwarder what to forward
-    configure_forwarder(instr, broker, topics['config'], prefix, topics['parameter'])
+    configure_forwarder(instr.parameters, broker, topics['config'], prefix, topics['parameter'])
 
     # Create a file-writer job
-    structure = augment_structure(instr, structure, title, prefix, topics['parameter'])
+    structure = augment_structure(instr.parameters, structure, title, prefix, topics['parameter'])
     if structure_out:
         from json import dump
         with open(structure_out, 'w') as f:
@@ -279,12 +379,4 @@ def conduct(
     print(f'Finished writing {path}')
 
     # De-register the forwarder topics (Don't bother since we're about to kill it?)
-    deconfigure_forwarder(instr, broker, topics['config'], prefix, topics['parameter'])
-
-    for service in services:
-        service.stop()
-
-    ### Repack the resulting file into contiguous memory
-    ## subprocess call to `h5repack -l CONTI ${filename} ${filename}.pack && mv ${filename}.pack ${filename}`
-
-    ### Insert the HDF5 representation of the instrument into the file, just incase
+    deconfigure_forwarder(instr.parameters, broker, topics['config'], prefix, topics['parameter'])

--- a/src/mccode_plumber/manage/orchestrate.py
+++ b/src/mccode_plumber/manage/orchestrate.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from mccode_antlr.instr import Instr
-from mccode_plumber.kafka import register_kafka_topics, all_exist
-from mccode_plumber.splitrun import make_parser
+
 
 def guess_instr_config(name: str):
     from os import access, R_OK
@@ -17,6 +16,121 @@ def guess_instr_calibration(name: str):
         return guess
     raise FileNotFoundError(f'Could not find {guess} in {name}')
 
+def guess_instr_efu(name: str):
+    from os import access, X_OK
+    guess = name.split('_')[0].split('.')[0].split('-')[0].lower()
+    if access(guess, X_OK):
+        return guess
+    raise FileNotFoundError(f'Could not find {guess} in {name}')
+
+
+def register_topics(broker: str, topics: list[str]):
+    """Ensure that topics are registered in the Kafka broker."""
+    from mccode_plumber.kafka import register_kafka_topics, all_exist
+    res = register_kafka_topics(broker, topics)
+    if not all_exist(res.values()):
+        raise RuntimeError(f'Missing Kafka topics? {res}')
+
+
+def configure_forwarder(instr: Instr, broker: str, config: str, prefix: str, topic: str):
+    """Configure forwarder by sending a configuration broker ADD streams for parameters
+
+    Parameters
+    ----------
+    instr : Instr
+        the source of parameters to build stream information for
+    broker : str
+        the Kafka broker that hosts the configuration and topic streams
+    config : str
+        the configuration stream name
+    prefix : str
+        the prefix to add to the stream source name for each parameter
+    topic : str
+        the Kafka topic to which updates will be sent, at the configuration broker
+    """
+    from mccode_plumber.forwarder import (
+        configure_forwarder as cf, forwarder_partial_streams as fps
+    )
+    cf(fps(prefix, topic, instr.parameters), f'{broker}/{config}', prefix, topic)
+
+
+def deconfigure_forwarder(instr: Instr, broker: str, config: str, prefix: str, topic: str):
+    """Stop forwarder by sending a configuration broker REMOVE streams for parameters
+
+        Parameters
+        ----------
+        instr : Instr
+            the source of parameters to build stream information for
+        broker : str
+            the Kafka broker that hosts the configuration and topic streams
+        config : str
+            the configuration stream name
+        prefix : str
+            the prefix to add to the stream source name for each parameter
+        topic : str
+            the Kafka topic to which updates will no longer be sent, at the configuration broker
+        """
+    from mccode_plumber.forwarder import (
+        reset_forwarder as rf, forwarder_partial_streams as fps
+    )
+    rf(fps(prefix, topic, instr.parameters), f'{broker}/{config}', prefix, topic)
+
+
+def augment_structure(instr: Instr, structure: dict, title: str, prefix: str, topic: str):
+    """Helper to add stream JSON entries for Instr parameters to a NexusStructure
+
+    Parameters
+    ----------
+    instr : Instr
+        Instrument which contains one or more runtime parameter
+    structure : dict
+        NexusStructure JSON representing the instrument
+    title : str
+        Informative string about the simulation, to be inserted in structure
+    prefix : str
+        EPICS prefix used to construct PV addresses from parameter names, this
+        is used here to construct the Kafka stream source as well
+    topic : str
+        the Kafka stream topic which will hold Forwarded PV updates
+    """
+    from mccode_plumber.writer import (
+        add_title_to_nexus_structure,  add_pvs_to_nexus_structure,
+        construct_writer_pv_dicts_from_parameters,
+    )
+    pvs = construct_writer_pv_dicts_from_parameters(instr.parameters, prefix, topic)
+    data = add_pvs_to_nexus_structure(structure, pvs)
+    data = add_title_to_nexus_structure(data, title)
+    return data
+
+
+def stop_writer(broker, job_topic, command_topic, job_id, timeout):
+    from time import sleep
+    from mccode_plumber.file_writer_control import WorkerJobPool
+    pool = WorkerJobPool(f'{broker}/{job_topic}', f'{broker}/{command_topic}')
+    sleep(timeout)
+    pool.try_send_stop_now(None, job_id)
+
+
+def start_writer(start_time, structure, filename, broker, job_topic, command_topic,
+                 timeout):
+    from uuid import uuid4
+    from mccode_plumber.writer import writer_start
+    job_id = str(uuid4())
+    success = False
+    try:
+        start, handler = writer_start(
+            start_time.isoformat(), structure, filename=filename, stop_time_string=None,
+            broker=broker, job_topic=job_topic, command_topic=command_topic,
+            timeout=timeout, job_id=job_id, wait=False
+        )
+        success = start.is_done()
+    except RuntimeError as e:
+        if job_id in str(e):
+            # starting the job failed, so try to kill it
+            stop_writer(broker, job_topic, command_topic, job_id, timeout)
+
+    return job_id, success
+
 
 def get_topics(data: dict):
     topics = set()
@@ -28,96 +142,146 @@ def get_topics(data: dict):
     return topics
 
 
-def conduct(instr: Instr, args, dump_structure=False):
-    from datetime import datetime, timezone
-    from mccode_plumber.epics import convert_instr_parameters_to_nt
-    from .efu import EventFormationUnitManager
-    from .epics import EPICSMailboxManager
-    from .forwarder import ForwarderManager
-    from .writer import WriterManager
+def load_structure_file(structure_file):
+    from os import access, R_OK
+    from json import load
+    if not (structure_file.exists() and structure_file.is_file() and access(structure_file, R_OK)):
+        raise ValueError('You must provide a nexus-structure file')
+    with open(structure_file, 'r') as f:
+        return load(f)
 
-    now = datetime.now(timezone.utc).isoformat(timespec='seconds').split('+')[0]
-    params = {
-        'broker': 'localhost:9092',
-        'work': Path().resolve(),
+
+def make_parser():
+    from argparse import BooleanOptionalAction
+    from mccode_plumber import __version__
+    from restage.splitrun import make_splitrun_parser
+    parser = make_splitrun_parser()
+    parser.prog = 'mp-splitrun-nexus'
+    parser.add_argument('-v' ,'--version', action='version', version=__version__)
+    # No need to specify the broker, or monitor source or topic names
+    parser.add_argument('--work', type=str, default=None, help='Working directory')
+    parser.add_argument('--structure', type=str, default=None, help='NeXus Structure JSON path')
+    parser.add_argument('--structure-out', type=str, default=None, help='Output configured structure JSON path')
+    parser.add_argument('--efu', type=str, default=None, help='EFU binary path/name')
+    parser.add_argument('--config', type=str, default=None, help='EFU configuration JSON')
+    parser.add_argument('--calibration', type=str, default=None, help='EFU calibration JSON')
+    parser.add_argument('--manage', action=BooleanOptionalAction, default=True, help='Manage services locally')
+    return parser
+
+
+def main():
+    from mccode_plumber.mccode import get_mcstas_instr
+    from restage.splitrun import parse_splitrun
+    from mccode_plumber.splitrun import monitors_to_kafka_callback_with_arguments
+    args, parameters, precision = parse_splitrun(make_parser())
+    instr = get_mcstas_instr(args.instrument[0])
+
+    structure = load_structure_file(args.structure if args.structure else Path(args.instrument[0]).with_suffix('.json'))
+    broker = 'localhost:9092'
+    monitor_source = 'mccode-to-kafka'
+    callback_topics = list(get_topics(structure))  # all structure-topics might be monitor topics?
+
+    callback, callback_args = monitors_to_kafka_callback_with_arguments(broker, monitor_source, callback_topics)
+    splitrun_kwargs = {
+        'args': args, 'parameters': parameters, 'precision': precision,
+        'callback': callback, 'callback_arguments': callback_args,
+    }
+    conduct_kwargs = {
+        'efu': args.efu, 'config': args.config, 'calibration': args.calibration,
+        'work': args.work, 'structure_out': args.structure_out, 'manage': args.manage,
+    }
+    for k in list(conduct_kwargs.keys()) + ['structure']:
+        delattr(args, k)
+    return conduct(instr, structure, broker, callback_topics, splitrun_kwargs, **conduct_kwargs)
+
+
+def conduct(
+        instr: Instr,
+        structure,
+        broker: str,
+        callback_topics: list[str],
+        splitrun_kwargs: dict,
+        efu: str = None,
+        config: str = None,
+        calibration: str = None,
+        work: str = None,
+        structure_out: str = None,
+        manage: bool = True,
+):
+    from datetime import datetime, timezone
+    from restage.splitrun import splitrun_args
+    from mccode_plumber.manage import (EventFormationUnit, EPICSMailbox, Forwarder, KafkaToNexus)
+
+    # now = datetime.now(timezone.utc).isoformat(timespec='seconds').split('+')[0]
+    now = datetime.now(timezone.utc)
+    prefix = 'mcstas:'
+    title = f'{instr.name} simulation {now}: {splitrun_kwargs["args"]}'
+    filename = f'{instr.name}_{now:%y%m%dT%H%M%S}.h5'
+    topics = {
+        'parameter': 'SimulatedParameters',
+        'event': 'SimulatedEvents',
         'config': 'ForwardConfig',
         'status': 'ForwardStatus',
-        'prefix': 'mcstas:',
         'command': 'WriterCommand',
         'job': 'WriterJob',
-        'event_source': f'{instr.name}_detector',
-        'event_topic': 'SimulatedEvents',
-        'parameter_topic': 'SimulatedParameters',
-        'title': f'{instr.name} simulation {now}: {args}',
-        'filename': f'{instr.name}_{now}.h5',
-        'origin': 'sample_stack',
-        'monitor_source': 'mccode-to-kafka',
     }
-    if (structure := params['work'] / f'{instr.name}.json').exists():
-        params['structure_file'] = structure
-    if dump_structure:
-        params['structure_dump'] = params['work'] / f'{instr.name}.dump.json'
 
-    # Start up services
-    efu = EventFormationUnitManager.start(
-        binary=instr.name,
-        config=args.config or guess_instr_config(name=instr.name),
-        calibration=args.calibration or guess_instr_calibration(name=instr.name),
-        broker=params['broker'],
-        topic=params['event_topic'],
-    )
-    forwarder = ForwarderManager.start(
-        broker=params['broker'],
-        config=params['config'],
-        status=params['status'],
-    )
-    epics = EPICSMailboxManager.start(
-        values=convert_instr_parameters_to_nt(instr.parameters),
-        prefix=params['prefix'],
-    )
-    writer = WriterManager.start(
-        broker=params['broker'],
-        work=params['work'],
-        command=params['command'],
-        jbo=params['job'],
+    # Start up services if they should be managed locally
+    services = () if not manage else (
+        EventFormationUnit.start(
+            binary=efu or guess_instr_efu(instr.name),
+            config=config or guess_instr_config(name=instr.name),
+            calibration=calibration or guess_instr_calibration(name=instr.name),
+            broker=broker,
+            topic=topics['event'],
+        ),
+        Forwarder.start(
+            broker=broker,
+            config=topics['config'],
+            status=topics['status'],
+        ),
+        EPICSMailbox.start(
+            parameters=instr.parameters,
+            prefix=prefix,
+        ),
+        KafkaToNexus.start(
+            broker=broker,
+            work=work,
+            command=topics['command'],
+            job=topics['job'],
+        ),
     )
 
-    # Configure topics:
-    to_register = [params['parameter_topic'], params['event_topic']]
-    # plus the da00 topics listed in the nexus structure json file:
-    if 'structure_file' in params:
-        from json import load
-        with open(params['structure_file']) as f:
-            topics = get_topics(load(f))
-        to_register.extend(topics)
-
-    res = register_kafka_topics(params['broker'], to_register)
-    if not all_exist(res.values()):
-        raise RuntimeError(f'Missing Kafka topics? {res}')
-
+    # Ensure stream topics exist
+    register_topics(broker, list(topics.values()) + callback_topics)
     # Tell the forwarder what to forward
-    # FIXME mp-forwarder-setup instr --prefix epics_prefix --config broker/config --topic parameter_topic
+    configure_forwarder(instr, broker, topics['config'], prefix, topics['parameter'])
 
     # Create a file-writer job
-    # FIXME mp-writer-write instr --prefix epicx_prefix --broker broker --job job
-    #       --command command --topic parameter_topic --event-source event_source
-    #       --event-topic event-topic --title title --filename filename
-    #       --ns-file structure_File --start-time {now} --origin origin --job-id {uuid}
+    structure = augment_structure(instr, structure, title, prefix, topics['parameter'])
+    if structure_out:
+        from json import dump
+        with open(structure_out, 'w') as f:
+            dump(structure, f)
 
-    ### Do the actual simulation
-    # FIXME call main in mccode_plumber.splitrun
+    job_id, success = start_writer(
+        now, structure, filename, broker, topics['job'], topics['command'], 2.0,
+    )
 
-    ### Wait for the file-writer to finish its job (possibly kill it)
+    # Do the actual simulation, calling into restage.splitrun after parsing,
+    # Using the provided callbacks to send monitor data to Kafka
+    splitrun_args(instr, **splitrun_kwargs)
 
-    ### De-register the forwarder topics (Don't bother since we're about to kill it)
+    # Wait for the file-writer to finish its job (possibly kill it)
+    stop_writer(broker, topics['job'], topics['command'], job_id, 2.0)
 
-    ### Stop the services
-    epics.stop()
-    writer.stop()
-    forwarder.stop()
-    efu.stop()
+    # De-register the forwarder topics (Don't bother since we're about to kill it?)
+    deconfigure_forwarder(instr, broker, topics['config'], prefix, topics['parameter'])
+
+    for service in services:
+        service.stop()
 
     ### Repack the resulting file into contiguous memory
-    ## Equivalent to `h5repack -l CONTI ${filename} ${filename}.pack && mv ${filename}.pack ${filename}`
+    ## subprocess call to `h5repack -l CONTI ${filename} ${filename}.pack && mv ${filename}.pack ${filename}`
 
     ### Insert the HDF5 representation of the instrument into the file, just incase

--- a/src/mccode_plumber/manage/orchestrate.py
+++ b/src/mccode_plumber/manage/orchestrate.py
@@ -169,7 +169,10 @@ def load_file_json(file: str | Path):
         return load(f)
 
 
-def get_instr_name_and_parameters(file):
+def get_instr_name_and_parameters(file: str | Path):
+    from mccode_plumber.manage.manager import ensure_readable_file
+    file = ensure_readable_file(file)
+
     if file.suffix == '.h5':
         # Shortcut loading the whole Instr:
         import h5py
@@ -187,10 +190,10 @@ def get_instr_name_and_parameters(file):
     raise ValueError('Unsupported file extension')
 
 
-def make_waiter_parser():
+def make_services_parser():
     from mccode_plumber import __version__
     from argparse import ArgumentParser
-    parser = ArgumentParser('mp-nexus-waiter')
+    parser = ArgumentParser('mp-nexus-services')
     parser.add_argument('instrument', type=str, help='Instrument .instr or .h5 file')
     parser.add_argument('-v', '--version', action='version', version=__version__)
     # No need to specify the broker, or monitor source or topic names
@@ -201,8 +204,8 @@ def make_waiter_parser():
     return parser
 
 
-def waiter():
-    args = make_waiter_parser().parse_args()
+def services():
+    args = make_services_parser().parse_args()
     instr_name, instr_parameters = get_instr_name_and_parameters(args.instrument)
     kwargs = {
         'instr_name': instr_name,

--- a/src/mccode_plumber/manage/writer.py
+++ b/src/mccode_plumber/manage/writer.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
-from mccode_plumber.manage.manager import Manager
+from .manager import Manager
+from .ensure import ensure_writable_directory, ensure_executable
 
 
 @dataclass
@@ -28,9 +29,6 @@ class KafkaToNexus(Manager):
 
     def __post_init__(self):
         from mccode_plumber.kafka import register_kafka_topics, all_exist
-        from mccode_plumber.manage.manager import (
-            ensure_writable_directory, ensure_executable
-        )
         self._command = ensure_executable(self._command)
         if self.broker is None:
             self.broker = 'localhost:9092'

--- a/src/mccode_plumber/manage/writer.py
+++ b/src/mccode_plumber/manage/writer.py
@@ -5,7 +5,7 @@ from mccode_plumber.manage.manager import Manager, ensure_path
 
 
 @dataclass
-class WriterManager(Manager):
+class KafkaToNexus(Manager):
     """
     Manage the execution of a kafka-to-nexus file writer
 

--- a/src/mccode_plumber/manage/writer.py
+++ b/src/mccode_plumber/manage/writer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from mccode_plumber.manage.manager import Manager, ensure_path
+from mccode_plumber.manage.manager import Manager
 
 
 @dataclass
@@ -24,20 +24,21 @@ class KafkaToNexus(Manager):
     command: str | None = None
     job: str | None = None
     verbosity: str | None = None
-    _command: str = 'kafka-to-nexus'
+    _command: Path = field(default_factory=lambda: Path('kafka-to-nexus'))
 
     def __post_init__(self):
-        from os import access, X_OK, W_OK
         from mccode_plumber.kafka import register_kafka_topics, all_exist
-        if not access(self._command, X_OK):
-            raise ValueError(f'{self._command} is not a valid command')
+        from mccode_plumber.manage.manager import (
+            ensure_writable_directory, ensure_executable
+        )
+        self._command = ensure_executable(self._command)
         if self.broker is None:
             self.broker = 'localhost:9092'
         if self.command is None:
             self.config = 'WriterCommand'
         if self.job is None:
             self.job = 'WriterJob'
-        self.work = ensure_path(self.work or Path(), W_OK, is_dir=True)
+        self.work = ensure_writable_directory(self.work or Path())
 
         res = register_kafka_topics(self.broker, [self.command, self.job])
         if not all_exist(res.values()):

--- a/src/mccode_plumber/manage/writer.py
+++ b/src/mccode_plumber/manage/writer.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from pathlib import Path
+from mccode_plumber.manage.manager import Manager, ensure_path
+
+
+@dataclass
+class WriterManager(Manager):
+    """
+    Manage the execution of a kafka-to-nexus file writer
+
+    Parameters
+    ----------
+    broker:     the name or address and port of the broker containing the needed
+                command and job topics (localhost:9092)
+    work:       the working directory for file output (`Path()`)
+    command:    the topic used for receiving commands (WriterCommand)
+    job:        the topic used for receiving jobs (WriterJob)
+    verbosity:  the level of output to print to STDOUT, any of
+                (trace, debug, info, warning, error, critical)
+    """
+    broker: str | None = None
+    work: Path | None = None
+    command: str | None = None
+    job: str | None = None
+    verbosity: str | None = None
+    _command: str = 'kafka-to-nexus'
+
+    def __post_init__(self):
+        from os import access, X_OK, W_OK
+        from mccode_plumber.kafka import register_kafka_topics, all_exist
+        if not access(self._command, X_OK):
+            raise ValueError(f'{self._command} is not a valid command')
+        if self.broker is None:
+            self.broker = 'localhost:9092'
+        if self.command is None:
+            self.config = 'WriterCommand'
+        if self.job is None:
+            self.job = 'WriterJob'
+        self.work = ensure_path(self.work or Path(), W_OK, is_dir=True)
+
+        res = register_kafka_topics(self.broker, [self.command, self.job])
+        if not all_exist(res.values()):
+            raise RuntimeError(f'Missing Kafka topics? {res}')
+
+    def __run_command__(self) -> list[str]:
+        args = [
+            self._command,
+            '--brokers', self.broker,
+            '--command-status-topic', self.command,
+            '--job-pool-topic', self.job,
+            f'--hdf-output-prefix={self.work}/',
+            '--kafka-error-timeout', '10s',
+            '--kafka-poll-timeout', '1s',
+            '--kafka-metadata-max-timeout', '10s',
+        ]
+        if self.verbosity in ('critical', 'error', 'warning', 'info', 'debug', 'trace'):
+            args.extend(['--verbosity', self.verbosity])
+        return args

--- a/src/mccode_plumber/manage/writer.py
+++ b/src/mccode_plumber/manage/writer.py
@@ -44,7 +44,7 @@ class KafkaToNexus(Manager):
 
     def __run_command__(self) -> list[str]:
         args = [
-            self._command,
+            self._command.as_posix(),
             '--brokers', self.broker,
             '--command-status-topic', self.command,
             '--job-pool-topic', self.job,

--- a/src/mccode_plumber/splitrun.py
+++ b/src/mccode_plumber/splitrun.py
@@ -22,6 +22,13 @@ def monitors_to_kafka_callback_with_arguments(broker: str, source: str, topics: 
 
     return callback, {'dir': 'root'}
 
+# def splitrun(instr, parameters, precision, args):
+#     from restage.splitrun import splitrun_args
+#     callback, callback_args = monitors_to_kafka_callback_with_arguments(args.broker,
+#                                                                         args.source,
+#                                                                         args.topic)
+#     return splitrun_args(instr, parameters, precision, args, callback=callback,
+#                          callback_arguments=callback_args)
 
 def main():
     from .mccode import get_mcstas_instr

--- a/src/mccode_plumber/splitrun.py
+++ b/src/mccode_plumber/splitrun.py
@@ -22,13 +22,6 @@ def monitors_to_kafka_callback_with_arguments(broker: str, source: str, topics: 
 
     return callback, {'dir': 'root'}
 
-# def splitrun(instr, parameters, precision, args):
-#     from restage.splitrun import splitrun_args
-#     callback, callback_args = monitors_to_kafka_callback_with_arguments(args.broker,
-#                                                                         args.source,
-#                                                                         args.topic)
-#     return splitrun_args(instr, parameters, precision, args, callback=callback,
-#                          callback_arguments=callback_args)
 
 def main():
     from .mccode import get_mcstas_instr

--- a/src/mccode_plumber/writer.py
+++ b/src/mccode_plumber/writer.py
@@ -139,6 +139,7 @@ def insert_events_in_nexus_structure(ns: dict, config: dict):
 
 def get_writer_pool(broker: str = None, job: str = None, command: str = None):
     from .file_writer_control import WorkerJobPool
+    print(f'Create a Writer pool for {broker=} {job=} {command=}')
     pool = WorkerJobPool(f"{broker}/{job}", f"{broker}/{command}")
     return pool
 
@@ -215,9 +216,9 @@ def writer_start(
     if timeout is not None:
         try:
             # ensure the start succeeds:
-            zero_time = datetime.now()
+            give_up_time = datetime.now() + timedelta(seconds=timeout)
             while not start.is_done():
-                if zero_time + timedelta(seconds=timeout) < datetime.now():
+                if give_up_time < datetime.now():
                     raise RuntimeError(f"Timed out while starting job {job.job_id}")
                 elif start.get_state() == CommandState.ERROR:
                     raise RuntimeError(f"Starting job {job.job_id} failed with message {start.get_message()}")


### PR DESCRIPTION
Producing NeXus file output via the ESS data collection pipeline requires the availability of at least five external services
- An appropriately configured Kafka broker to collect data from providers and stream it to consumers
- An EPICS mailbox server for collecting simulation-time parameters
- An EPICS to Kafka Forwarder to send those simulation-time parameters to a Kafka topic
- An Event-Formation-Unit to accept packets of events from a Readout Master Module and send derived event data to a Kafka topic
- And a kafka-to-nexus file-writer to collect the streams into a NeXus file

Previously, a series of Docker/Podman containers, each with an entrypoint script, and two orchestrating bash scripts were used to successfully drive `mp-splitrun` to produce NeXus file output.

In order to support running simulations where neither Docker nor Podman are available but Apptainer is (e.g., most HPC systems and the ESS VISA virtual machines) the necessary binaries for the above services were packaged into new containers along side `mccode-pooch` and its dependencies.
This provided an opportunity to move all service management and orchestration into the Python code, to enable simpler system debugging and, hopefully, a simpler user interface.

To use the new functionality, a user should run (in three different terminals), Kafka
```
~$ apptainer run stacktainer/kafka_1.1.sif
```
the containerized services
```
~$ apptainer exec stacktainer/splitrun_5.0.sif mp-nexus-services {instrument}.{h5|instr} [other options]
```
and the orchestrated splitrun runner
```
~$ apptainer exec stacktainer/splitrun_5.0.sif mp-nexus-splitrun {instrument}.{h5|instr} [orchestration options] [mp-splitrun options] [splitrun options] [splitrun parameters]
```
