### PR TITLE
[Ref] decouple tests from internal restage changes 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,9 @@ dependencies = [
     'p4p',
     'kafka-python>=2.2.11',
     'ess-streaming-data-types>=0.14.0',
-    'restage>=0.8.1',
+    'restage>=0.8.2',
     'mccode-to-kafka>=0.2.2',
-    'moreniius>=0.5.0',
+    'moreniius>=0.5.1',
     'icecream',
     'ephemeral-port-reserve',
 ]

--- a/tests/test_splitrun.py
+++ b/tests/test_splitrun.py
@@ -1,27 +1,20 @@
 import unittest
+from mccode_plumber.splitrun import make_parser
+from restage.splitrun import args_fixup
 
-# FIXME These tests exercise internal details of the splitrun parser,
-#       which we don't depend on since we _always_ call `parse_splitrun({our parser}`)
-#       which rearranges ArgParse's results before returning
-#       (args, parameters, precision) therefore, directly checking the ArgParse result
-#       is fraught and these tests may fail at any internal change in restage
-# TODO  A future restage release will include an `args_fixup` function that can be used
-#       to get the correct output args of `parse_splitrun` in our testing here.
 
 class SplitrunTestCase(unittest.TestCase):
     def test_parsing(self):
-        from mccode_plumber.splitrun import make_parser
         parser = make_parser()
-        args = parser.parse_args(['--broker', 'l:9092', '--source', 'm', '-n', '10000', 'inst.h5', '--', 'a=1:4', 'b=2:5'])
+        args = args_fixup(parser.parse_args(['--broker', 'l:9092', '--source', 'm', '-n', '10000', 'inst.h5', '--', 'a=1:4', 'b=2:5']))
         self.assertEqual(args.instrument, 'inst.h5')
         self.assertEqual(args.broker, 'l:9092')
         self.assertEqual(args.source, 'm')
-        self.assertEqual(args.ncount, (None, 10000, None))
+        self.assertEqual(args.ncount, 10000)
         self.assertEqual(args.parameters, ['a=1:4', 'b=2:5'])
         self.assertFalse(args.parallel)
 
     def test_mixed_order_throws(self):
-        from mccode_plumber.splitrun import make_parser
         parser = make_parser()
         parser.prog = "{{This failed before but works now? Why did it stop throwing?}}"
         pa = parser.parse_args
@@ -39,17 +32,37 @@ class SplitrunTestCase(unittest.TestCase):
         self.assertEqual(sort_args(['inst.h5', '-n', '10000', 'a=1:4', 'b=2:5']), ['-n', '10000', 'inst.h5', 'a=1:4', 'b=2:5'])
 
     def test_sorted_mixed_order_does_not_throw(self):
-        from mccode_plumber.splitrun import make_parser
         from mccode_antlr.run.runner import sort_args
         parser = make_parser()
-        args = parser.parse_args(sort_args(['inst.h5', '--broker', 'www.github.com:9093', '--source', 'dev/null',
-                                            '-n', '123', '--parallel', '--', 'a=1:4', 'b=2:5']))
+        args = args_fixup(parser.parse_args(sort_args(['inst.h5', '--broker', 'www.github.com:9093', '--source', 'dev/null',
+                                            '-n', '123', '--parallel', '--', 'a=1:4', 'b=2:5'])))
         self.assertEqual(args.instrument, 'inst.h5')
         self.assertEqual(args.broker, 'www.github.com:9093')
         self.assertEqual(args.source, 'dev/null')
-        self.assertEqual(args.ncount, (None, 123, None))
+        self.assertEqual(args.ncount, 123)
         self.assertEqual(args.parameters, ['a=1:4', 'b=2:5'])
         self.assertTrue(args.parallel)
+
+    def test_ncount_limits(self):
+        args = args_fixup(make_parser().parse_args([
+            'inst.json', '--broker', 'l:9092', '--source', 'm',
+            '-n', '1M', '--nmin', '100k', '--nmax', '1G'
+        ]))
+        self.assertEqual(args.ncount, 10**6)
+        self.assertEqual(args.nmin, 100000)
+        self.assertEqual(args.nmax, 10**9)
+        args = args_fixup(make_parser().parse_args([
+            'inst.json', '--broker', 'l:9092', '--source', 'm', '-n', '100k]1M[1G'
+        ]))
+        self.assertEqual(args.ncount, 10 ** 6)
+        self.assertEqual(args.nmin, 100000)
+        self.assertEqual(args.nmax, 10 ** 9)
+        args = args_fixup(make_parser().parse_args([
+            'inst.json', '--broker', 'l:9092', '--source', 'm', '-n', '1-1Ki+Mi'
+        ]))
+        self.assertEqual(args.ncount, 2**10)
+        self.assertEqual(args.nmin, 1)
+        self.assertEqual(args.nmax, 2**20)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Bump versions for `restage` and `moreniius` for a `mccode-antlr` bugfix, enabing fix for #30 