### PR TITLE
[Add] flag for new post-send delete keyword for splitrun callback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ dependencies = [
     'kafka-python>=2.2.11',
     'ess-streaming-data-types>=0.14.0',
     'restage>=0.10.1',
-    'mccode-to-kafka>=0.3.1',
-    'moreniius>=0.6.3',
+    'mccode-to-kafka>=0.5.0',
+    'moreniius>=0.7.0',
     'icecream',
     'ephemeral-port-reserve',
 ]


### PR DESCRIPTION
Fixes #54 by removing histogram .dat files once they're sent to the Kafka server