### PR TITLE
[Add] managed process output filtering and triage

### DIFF
--- a/src/mccode_plumber/manage/manager.py
+++ b/src/mccode_plumber/manage/manager.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from subprocess import Popen, PIPE
 from threading import Thread
 from enum import Enum
@@ -13,19 +13,78 @@ class IOType(Enum):
 
 
 @dataclass
+class Triage:
+    level: str = field(default=lambda: 'info')
+    ignore: list[str] = field(default_factory=list)
+    patterns: dict[str, list[str]] = field(default_factory=lambda: {
+        'critical': [r'\bcritical\b', r'^cri'],
+        'error': [r'\berror\b', r'exception', r'traceback', r'^err' ],
+        'warning': [r'\bwarn(ing)?\b', r'deprecated', r'^war'],
+        'notice': [r'\bnotice\b', r'^not'],
+        'info': [r'\binfo\b', r'starting', r'done'],
+        'hint': [r'\bhint\b'],
+        'debug': [r'\bdebug\b', r'^deb', r'^dbg'],
+    })
+    styles: dict[str, str] = field(default_factory=lambda: {
+        'critical': Fore.MAGENTA + Style.BRIGHT,
+        'error': Fore.RED + Style.BRIGHT,
+        'warning': Fore.YELLOW + Style.BRIGHT,
+        'notice': Fore.CYAN + Style.BRIGHT,
+        'info': Fore.GREEN,
+        'hint': Fore.BLUE,
+        'debug': Fore.WHITE + Style.BRIGHT,
+        'default': Fore.WHITE,
+    })
+
+    def _filtered_level(self, level: str) -> bool:
+        def _level_value(v: str):
+            for i, lvl in enumerate(self.patterns.keys()):
+                if v == lvl:
+                    return i
+            return -1
+        return _level_value(level) > _level_value(self.level)
+
+    def _style_line(self, level: str, line: str):
+        return self.styles.get(level, '') + line + Style.RESET_ALL
+
+    def __call__(self, line: str) -> tuple[bool, str | None]:
+        import re
+        # If the line contains an ignored keyword, ignore it.
+        if any(kw in line for kw in self.ignore):
+            return True, None
+        # Check if we can identify the status level of this message
+        for level, patterns in self.patterns.items():
+            for pattern in patterns:
+                if re.search(pattern, line, re.IGNORECASE):
+                    return self._filtered_level(level), self._style_line(level, line)
+        return self._filtered_level('default'), self._style_line('default', line)
+
+
+@dataclass
 class Manager:
     """
     Command and control of a process
 
     Properties
     ----------
+    name: str
+        The name of the process, used as a prefix for all printed status messages
+    style: AnsiStyle
+        Format string to style the printed process name
+    _triage: Triage
+        An object to filter status messages and identify severity levels
+        applying its own message styling based on the identified level
     _process:   a subprocess.Popen instance
+    _stdout_thread: Thread
+    _stderr_thread: Thread
     """
     name: str
     style: AnsiStyle
+    triage: Triage
     _process: Popen | None
     _stdout_thread: Thread | None
     _stderr_thread: Thread | None
+    _name_padding: int
 
     def __run_command__(self) -> list[str]:
         return []
@@ -37,6 +96,18 @@ class Manager:
     def fieldnames(cls) -> list[str]:
         from dataclasses import fields
         return [field.name for field in fields(cls)]
+
+    @property
+    def name_padding(self):
+        return self._name_padding
+
+    @name_padding.setter
+    def name_padding(self, value: int):
+        self._name_padding = value
+
+    def _pretty_name(self):
+        padding = ' ' * self.name_padding
+        return f'{self.style}{self.name}:{Style.RESET_ALL}{padding}'
 
     def _read_stream(self, stream, io_type: IOType):
         """Read lines from stream and print them until EOF.
@@ -51,8 +122,10 @@ class Manager:
             for line in iter(stream.readline, ''):
                 if not line:
                     break
-                # format and print the line, preserving original behaviour
-                formatted = f'{self.style}{self.name}:{Style.RESET_ALL} {line}'
+                ignored, line = self.triage(line)
+                if ignored:
+                    continue
+                formatted = f'{self._pretty_name()} {line}'
                 if io_type == IOType.stdout:
                     print(formatted, end='')
                 else:
@@ -79,6 +152,10 @@ class Manager:
             kwargs['name'] = 'Managed process'
         if 'style' not in kwargs:
             kwargs['style'] = Fore.WHITE + Back.BLACK
+        if 'triage' not in kwargs:
+            kwargs['triage'] = Triage()
+        if '_name_padding' not in kwargs:
+            kwargs['_name_padding'] = 0
 
         manager = cls(**kwargs)
 

--- a/src/mccode_plumber/manage/orchestrate.py
+++ b/src/mccode_plumber/manage/orchestrate.py
@@ -261,6 +261,7 @@ def load_in_wait_load_out(
         )
         from mccode_plumber.manage.forwarder import forwarder_verbosity
         from mccode_plumber.manage.writer import writer_verbosity
+        from mccode_plumber.manage.manager import Triage
 
         # Start up services if they should be managed locally
         if manage:
@@ -283,7 +284,10 @@ def load_in_wait_load_out(
                 efu = [EventFormationUnitConfig.from_dict(data)]
             things = tuple(
                 EventFormationUnit.start(
-                    style=Fore.BLUE, broker=broker, **x.to_dict()
+                    style=Fore.BLUE,
+                    broker=broker,
+                    triage=Triage(ignore=["graphite", ":2003 failed"]),
+                    **x.to_dict()
                 ) for x in efu) + (
                 Forwarder.start(
                     name='FWD',
@@ -309,6 +313,9 @@ def load_in_wait_load_out(
                     verbosity=writer_verbosity(verbosity_writer),
                 ),
             )
+            longest_name = max(len(thing.name) for thing in things)
+            for thing in things:
+                thing.name_padding = longest_name - len(thing.name)
         else:
             things = ()
 


### PR DESCRIPTION
Event Formation Units now automatically ignore graphite error related output

Fixes #56 using the first option. The second proposed option, controlling a graphite server directly, proved challenging in a docker-free environment.