### PR TITLE
[Update] moreniius and restage for mccode-antlr v0.19.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 dynamic = ['version']
 
 [project.optional-dependencies]
-test = ["pytest", "niess>=0.1.4"]
+test = ["pytest", "niess>=0.2.0"]
 
 [project.scripts]
 mp-splitrun = 'mccode_plumber.splitrun:main'
@@ -67,7 +67,7 @@ legacy_tox_ini = """
     [testenv]
     deps =
         pytest
-        niess>=0.1.4
+        niess>=0.2.0
     commands = pytest tests
 
     [testenv:type]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,15 @@ dependencies = [
     'p4p',
     'kafka-python>=2.2.11',
     'ess-streaming-data-types>=0.14.0',
-    'restage>=0.10.4',
+    'restage>=0.11.0',
     'mccode-to-kafka>=0.5.0',
-    'moreniius>=0.8.5',
+    'moreniius>=0.9.0',
     'icecream',
     'ephemeral-port-reserve',
+    "mccode-antlr>=0.19.0",
 ]
 readme = "README.md"
+requires-python = ">=3.11"
 authors = [
     { name = "Gregory Tucker", email = "gregory.tucker@ess.eu" },
 ]


### PR DESCRIPTION
This pull request updates several dependencies and adds new requirements to the `pyproject.toml` file. The main focus is on keeping dependencies up-to-date and ensuring compatibility with Python 3.11 and above.

Dependency updates and requirements:

* Updated `restage` dependency to version `>=0.11.0` and `moreniius` to version `>=0.9.0` to ensure compatibility with the latest features and bug fixes.
* Added `mccode-antlr>=0.19.0` as a new dependency, to support improved `Expr`.
* Specified `requires-python = ">=3.11"` to enforce usage of Python 3.11 or newer.