### PR TITLE
Update mccode-antlr to v0.21.0 and restage dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = 'setuptools.build_meta'
 name = 'mccode-plumber'
 dependencies = [
     'p4p',
-    'kafka-python>=2.2.11',
+    'kafka-python>=2.2.11,<2.3.0',
     'ess-streaming-data-types>=0.14.0',
     'restage>=0.13.0',
     'mccode-to-kafka>=0.5.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,12 @@ dependencies = [
     'p4p',
     'kafka-python>=2.2.11',
     'ess-streaming-data-types>=0.14.0',
-    'restage>=0.11.0',
+    'restage>=0.13.0',
     'mccode-to-kafka>=0.5.0',
-    'moreniius>=0.9.0',
+    'moreniius>=0.10.0',
     'icecream',
     'ephemeral-port-reserve',
-    "mccode-antlr>=0.19.0",
+    "mccode-antlr>=0.21.0",
 ]
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
This pull request updates several dependencies in the `pyproject.toml` file to newer versions. These updates help ensure compatibility with the latest features and bug fixes from upstream libraries.

Dependency version updates:

* Updated `restage` to version `>=0.13.0`
* Updated `moreniius` to version `>=0.10.0`
* Updated `mccode-antlr` to version `>=0.21.0`